### PR TITLE
Watch the path configured in 'fileState' and immediately pass changes on to HomeKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "object-assign": "^4.0.1",
-    "file-exists": "^3.0.2"
+    "file-exists": "^3.0.2",
+    "chokidar": "^2.0.4"
   }
 }


### PR DESCRIPTION
This monitors the file pointed to by the 'fileState' parameter (if configured) and immediately changes the switch state in HomeKit whenever it appears/disappears. 

This prevents the file state getting out of sync with the switch state, especially if there is a third-party process that creates/deletes the file. You can see it in action by renaming the file in Finder (if on the Mac) and immediately see the switch turn off in the Home app, and vice versa when you rename the file back to the configured path.