### PR TITLE
Fix state command

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ script2Accessory.prototype.setState = function(powerOn, callback) {
 
 script2Accessory.prototype.getState = function(callback) {
   var accessory = this;
-  var stdout = "none";  
   
   if (this.fileState) {
     var flagFile = fileExists.sync(this.fileState);

--- a/index.js
+++ b/index.js
@@ -58,7 +58,6 @@ script2Accessory.prototype.setState = function(powerOn, callback) {
 
 script2Accessory.prototype.getState = function(callback) {
   var accessory = this;
-  var command = accessory['stateCommand'];
   var stdout = "none";  
   
   if (this.fileState) {
@@ -67,7 +66,7 @@ script2Accessory.prototype.getState = function(callback) {
     callback(null, flagFile);
   }
   else if (this.stateCommand) {
-    exec(command, function (error, stdout, stderr) {
+    exec(this.stateCommand, function (error, stdout, stderr) {
       var cleanOut=stdout.trim().toLowerCase();
       accessory.log('State of ' + accessory.name + ' is: ' + cleanOut);
       callback(null, cleanOut == accessory.onValue);

--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 var Service;
 var Characteristic;
 
-var sys = require('sys');
-    exec = require('child_process').exec;
-    assign = require('object-assign');
-    fileExists = require('file-exists');
-    chokidar = require('chokidar');
+var exec = require('child_process').exec;
+var assign = require('object-assign');
+var fileExists = require('file-exists');
+var chokidar = require('chokidar');
 
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ script2Accessory.prototype.getState = function(callback) {
   }
   else if (this.stateCommand) {
     exec(this.stateCommand, function (error, stdout, stderr) {
+      if (stderr) { return; }
       var cleanOut=stdout.trim().toLowerCase();
       accessory.log('State of ' + accessory.name + ' is: ' + cleanOut);
       callback(null, cleanOut == accessory.onValue);


### PR DESCRIPTION
This pull request fixes the name of the state command variable. The `sys` module was also removed as it is unused and outputs a [deprecation warning](https://nodejs.org/api/deprecations.html#deprecations_dep0025_require_sys).