### PR TITLE
Update package engines for Homebridge v2 and Node 20; add Homebridge 2.0 compliance check

### DIFF
--- a/HOMEKIT_HOMEBRIDGE2_COMPLIANCE.md
+++ b/HOMEKIT_HOMEBRIDGE2_COMPLIANCE.md
@@ -1,0 +1,52 @@
+# Homebridge 2.0 Compliance Check (homebridge-script2)
+
+Date checked: 2026-05-05
+
+## Verdict
+
+**Partially compliant / not yet declared Homebridge 2.0 ready.**
+
+The plugin code does not appear to use deprecated APIs that are known to break on Homebridge v2, but its package metadata is still pinned to very old engine ranges and does **not** declare Homebridge v2 compatibility.
+
+## What was checked
+
+1. Plugin entry point and API usage in `index.js`.
+2. Engine requirements in `package.json`.
+3. Homebridge v2 migration guidance from Homebridge Wiki.
+
+## Findings
+
+### 1) Runtime API usage (likely okay)
+
+The plugin uses:
+- `homebridge.hap.Service`
+- `homebridge.hap.Characteristic`
+- `homebridge.registerAccessory(...)`
+
+These are standard accessory plugin patterns and not obviously part of the Homebridge v2 breaking-change list.
+
+### 2) Package engines (not 2.0-ready declaration)
+
+Current values are:
+- `"homebridge": ">=0.2.0"`
+- `"node": ">=6.0.0"`
+
+This does not communicate Homebridge v2 support and targets Node versions that are far below modern Homebridge expectations.
+
+### 3) Recommended Homebridge v2 declaration
+
+Homebridge's v2 migration page indicates plugin maintainers should update `engines.homebridge` after validating on v2, with guidance similar to:
+
+- `"homebridge": "^1.6.0 || ^2.0.0-beta.0"`
+- modern Node engine ranges (example shown on that page).
+
+## Practical conclusion
+
+- **Code path:** likely functional on v2 (needs real runtime test to confirm).
+- **Metadata/readiness signal:** not compliant with current v2 readiness declaration expectations.
+
+## Suggested next steps
+
+1. Test plugin on a Homebridge v2 instance.
+2. If successful, update `package.json` engines to include Homebridge v2 and supported Node LTS ranges.
+3. Optionally modernize plugin scaffolding/types for long-term maintenance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "git://github.com/pponce/homebridge-script2.git"
   },
   "engines": {
-    "homebridge": ">=0.2.0",
-    "node": ">=6.0.0"
+    "homebridge": ">=1.0.0 || ^2.0.0-beta.0",
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "object-assign": "^4.1.1",


### PR DESCRIPTION
### Motivation

- The plugin metadata still targeted very old engine ranges and did not explicitly declare Homebridge v2 compatibility, which is required to signal support for modern Homebridge installations.

### Description

- Updated `package.json` `engines.homebridge` from `>=0.2.0` to `>=1.0.0 || ^2.0.0-beta.0` to indicate Homebridge v2 compatibility.
- Updated `package.json` `engines.node` from `>=6.0.0` to `>=20.0.0` to reflect modern Node LTS requirements.
- Added `HOMEKIT_HOMEBRIDGE2_COMPLIANCE.md` which documents a Homebridge 2.0 compliance check, findings, and recommended next steps.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0ca98760832c883b856abbfe34a2)