### PR TITLE
Add dynamic `Script2Platform`, refactor device logic, and manage file watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,55 @@ Because it appears that the original [homebridge-script](https://github.com/xxco
 While this fork depends on file-exists there is no need to install it seperately for this fork, as I've included it as a dependency.
 
 
+
+## Platform mode (beta)
+
+This plugin now supports **both**:
+- Legacy accessory mode (backward compatible)
+- New dynamic platform mode (`Script2Platform`)
+
+### Backward compatibility
+- Existing accessory-based setups remain supported and unchanged.
+- If you choose to move to platform mode, you should remove the existing setup completely and start fresh with a new `platforms` configuration.
+
+### Strong recommendation: use a Child Bridge
+Because this plugin depends on external scripts and shell execution, it is highly recommended to run it in a dedicated **Child Bridge** for reliability and isolation.
+
+### Platform configuration parameters
+Each entry in `devices` supports the same options as accessory mode:
+
+Name            | Value         | Required                                    | Notes
+--------------- | ------------- | ------------------------------------------- | -------------
+`name`          | _(custom)_    | yes                                         | Name of accessory that will appear in Home app and is required
+`on`            | _(custom)_    | yes                                         | Script/command to execute the on action
+`off`           | _(custom)_    | yes                                         | Script/command to execute the off action
+`fileState`     | _(custom)_    | fileState or state is required (see note)   | File used as current state flag
+`state`         | _(custom)_    | fileState or state is required (see note)   | Script to determine current state
+`on_value`      | _(custom)_    | no* (default set to `"true"`)             | Value matched against `state` command output
+`unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
+
+### Platform configuration example
+
+```
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "devices": [
+      {
+        "name": "RPC3 Socket 1",
+        "on": "/var/homebridge/rpc3control/on.sh 1",
+        "off": "/var/homebridge/rpc3control/off.sh 1",
+        "state": "/var/homebridge/rpc3control/state.sh 1",
+        "fileState": "/var/homebridge/rpc3control/script1.flag",
+        "on_value": "true",
+        "unique_serial": "platform-1234567"
+      }
+    ]
+  }
+]
+```
+
 ## Installation
 (Requires node >=6.0.0)
 

--- a/index.js
+++ b/index.js
@@ -5,17 +5,109 @@ const exec = require("child_process").exec;
 const fileExists = require("file-exists");
 const chokidar = require("chokidar");
 
+const PLUGIN_NAME = "homebridge-script2";
+const ACCESSORY_NAME = "Script2";
+const PLATFORM_NAME = "Script2Platform";
+
 module.exports = function (homebridge) {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
-  homebridge.registerAccessory(
-    "homebridge-script2",
-    "Script2",
-    script2Accessory
-  );
+
+  // Legacy accessory mode (backward compatible)
+  homebridge.registerAccessory(PLUGIN_NAME, ACCESSORY_NAME, script2Accessory);
+
+  // New dynamic platform mode (cached accessories + configureAccessory)
+  homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, Script2Platform, true);
 };
 
+class Script2Platform {
+  constructor(log, config, api) {
+    this.log = log;
+    this.config = config || {};
+    this.api = api;
+    this.accessories = new Map();
+    this.instances = new Map();
+
+    this.api.on("didFinishLaunching", () => {
+      this.discoverDevices();
+    });
+  }
+
+  configureAccessory(accessory) {
+    this.log.info(`Restoring cached accessory: ${accessory.displayName}`);
+    this.accessories.set(accessory.UUID, accessory);
+  }
+
+  discoverDevices() {
+    const devices = Array.isArray(this.config.devices) ? this.config.devices : [];
+
+    if (devices.length === 0) {
+      this.log.warn("No devices configured for Script2Platform.");
+      return;
+    }
+
+    const configuredUuids = new Set();
+
+    for (const deviceConfig of devices) {
+      const name = deviceConfig?.name;
+      if (!name) {
+        this.log.error("Skipping platform device with missing required 'name'.");
+        continue;
+      }
+
+      const uuid = this.api.hap.uuid.generate(`${PLUGIN_NAME}:${name}`);
+      configuredUuids.add(uuid);
+
+      let platformAccessory = this.accessories.get(uuid);
+      if (platformAccessory) {
+        this.log.info(`Configuring cached platform accessory: ${name}`);
+        platformAccessory.context.device = deviceConfig;
+        this.api.updatePlatformAccessories([platformAccessory]);
+      } else {
+        this.log.info(`Adding new platform accessory: ${name}`);
+        platformAccessory = new this.api.platformAccessory(name, uuid);
+        platformAccessory.context.device = deviceConfig;
+        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [platformAccessory]);
+        this.accessories.set(uuid, platformAccessory);
+      }
+
+      const instance = new Script2DeviceLogic(this.log, platformAccessory.context.device);
+      instance.bindServices(platformAccessory);
+      this.instances.set(uuid, instance);
+    }
+
+    for (const [uuid, accessory] of this.accessories.entries()) {
+      if (!configuredUuids.has(uuid)) {
+        this.log.info(`Removing stale cached accessory: ${accessory.displayName}`);
+        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+        this.accessories.delete(uuid);
+        const staleInstance = this.instances.get(uuid);
+        if (staleInstance) {
+          staleInstance.shutdown();
+          this.instances.delete(uuid);
+        }
+      }
+    }
+  }
+}
+
 function script2Accessory(log, config) {
+  this.logic = new Script2DeviceLogic(log, config);
+}
+
+script2Accessory.prototype.setState = function (powerOn, callback) {
+  this.logic.setState(powerOn, callback);
+};
+
+script2Accessory.prototype.getState = function (callback) {
+  this.logic.getState(callback);
+};
+
+script2Accessory.prototype.getServices = function () {
+  return this.logic.buildServices();
+};
+
+function Script2DeviceLogic(log, config) {
   this.log = log;
   this.service = "Switch";
 
@@ -27,46 +119,71 @@ function script2Accessory(log, config) {
   this.fileState = config["fileState"] || false;
   this.uniqueSerial = config["unique_serial"] || "script2 Serial Number";
   this.onValue = this.onValue.trim().toLowerCase();
+  this.watcher = null;
+
   try {
-    this.currentState = this.fileState
-      ? fileExists.sync(this.fileState)
-      : false;
+    this.currentState = this.fileState ? fileExists.sync(this.fileState) : false;
   } catch (err) {
     this.log.error(`Error checking initial file state: ${err.message}`);
     this.currentState = false;
   }
+}
 
-  this.setStateHandler = function (powerOn, callback) {
-    function setStateHandlerExecCallback(error, stdout, stderr) {
-      if (error || stderr) {
-        const errMessage = stderr
-          ? `${stderr} (${error?.message ?? 'unknown error'})`
-          : `${error?.message ?? 'unknown error'}`;
-        this.log.error(`Set State returned an error: ${errMessage}`);
-        callback(new Error(errMessage), null);
-        return;
-      }
+Script2DeviceLogic.prototype.shutdown = function () {
+  if (this.watcher) {
+    this.watcher.close().catch((err) => {
+      this.log.warn(`Error while closing file watcher for ${this.name}: ${err.message}`);
+    });
+    this.watcher = null;
+  }
+};
 
-      const commandOutput = stdout.trim().toLowerCase();
-      this.log.debug(`Set State Command returned ${commandOutput}`);
+Script2DeviceLogic.prototype.setState = function (powerOn, callback) {
+  this.log.info(`Setting ${this.name} to ${powerOn ? "ON" : "OFF"}...`);
 
-      this.currentState = powerOn;
-      this.log.info(`Set ${this.name} to ${powerOn ? "ON" : "OFF"}`);
-
-      callback(null, powerOn);
+  const command = powerOn ? this.onCommand : this.offCommand;
+  this.log.debug(`Executing command: ${command}`);
+  exec(command, (error, stdout, stderr) => {
+    if (error || stderr) {
+      const errMessage = stderr
+        ? `${stderr} (${error?.message ?? "unknown error"})`
+        : `${error?.message ?? "unknown error"}`;
+      this.log.error(`Set State returned an error: ${errMessage}`);
+      callback(new Error(errMessage), null);
+      return;
     }
 
-    const command = powerOn ? this.onCommand : this.offCommand;
-    this.log.debug(`Executing command: ${command}`);
-    exec(command, setStateHandlerExecCallback.bind(this));
-  };
+    const commandOutput = stdout.trim().toLowerCase();
+    this.log.debug(`Set State Command returned ${commandOutput}`);
 
-  this.getStateHandler = function (callback) {
-    function getStateHandlerExecCallback(error, stdout, stderr) {
+    this.currentState = powerOn;
+    this.log.info(`Set ${this.name} to ${powerOn ? "ON" : "OFF"}`);
+
+    callback(null, powerOn);
+  });
+};
+
+Script2DeviceLogic.prototype.getState = function (callback) {
+  this.log.info(`Getting ${this.name} state...`);
+
+  if (this.fileState) {
+    try {
+      const poweredOn = fileExists.sync(this.fileState);
+      this.log.info(`State of ${this.name} is: ${poweredOn ? "ON" : "OFF"}`);
+      callback(null, poweredOn);
+    } catch (err) {
+      this.log.error(`Error checking file state: ${err.message}`);
+      callback(err, null);
+    }
+    return;
+  }
+
+  if (this.stateCommand) {
+    const command = this.stateCommand;
+    this.log.debug(`Executing command: ${command}`);
+    exec(command, (error, stdout, stderr) => {
       if (error || stderr) {
-        const errMessage = stderr
-          ? `${stderr} (${error.message})`
-          : error.message;
+        const errMessage = stderr ? `${stderr} (${error.message})` : error.message;
         this.log.error(`Get State returned an error: ${errMessage}`);
         callback(new Error(errMessage), null);
         return;
@@ -78,44 +195,23 @@ function script2Accessory(log, config) {
       const poweredOn = cleanCommandOutput == this.onValue;
       this.log.info(`State of ${this.name} is: ${poweredOn ? "ON" : "OFF"}`);
       callback(null, poweredOn);
-    }
-
-    const command = this.stateCommand;
-    this.log.debug(`Executing command: ${command}`);
-    exec(command, getStateHandlerExecCallback.bind(this));
-  };
-
-  this.getFileStateHandler = function (callback) {
-    try {
-      const poweredOn = fileExists.sync(this.fileState);
-      this.log.info(`State of ${this.name} is: ${poweredOn ? "ON" : "OFF"}`);
-      callback(null, poweredOn);
-    } catch (err) {
-      this.log.error(`Error checking file state: ${err.message}`);
-      callback(err, null);
-    }
-  };
-}
-
-script2Accessory.prototype.setState = function (powerOn, callback) {
-  this.log.info(`Setting ${this.name} to ${powerOn ? "ON" : "OFF"}...`);
-  this.setStateHandler(powerOn, callback);
-};
-
-script2Accessory.prototype.getState = function (callback) {
-  this.log.info(`Getting ${this.name} state...`);
-  if (this.fileState) {
-    this.getFileStateHandler(callback);
-  } else if (this.stateCommand) {
-    this.getStateHandler(callback);
-  } else {
-    this.log.error("Must set config value for fileState or state.");
+    });
+    return;
   }
+
+  this.log.error("Must set config value for fileState or state.");
+  callback(new Error("Must set config value for fileState or state."), null);
 };
 
-script2Accessory.prototype.getServices = function () {
-  const informationService = new Service.AccessoryInformation();
-  const switchService = new Service.Switch(this.name);
+Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
+  const informationService =
+    platformAccessory.getService(Service.AccessoryInformation) ||
+    platformAccessory.addService(Service.AccessoryInformation);
+
+  const switchService =
+    platformAccessory.getService(Service.Switch) ||
+    platformAccessory.addService(Service.Switch, this.name);
+
   const theSerial = this.uniqueSerial.toString();
 
   informationService
@@ -123,16 +219,17 @@ script2Accessory.prototype.getServices = function () {
     .setCharacteristic(Characteristic.Model, "script2 Model")
     .setCharacteristic(Characteristic.SerialNumber, theSerial);
 
-  const characteristic = switchService
-    .getCharacteristic(Characteristic.On)
-    .on("set", this.setState.bind(this));
+  const characteristic = switchService.getCharacteristic(Characteristic.On);
+  characteristic.removeAllListeners("set");
+  characteristic.on("set", this.setState.bind(this));
 
+  characteristic.removeAllListeners("get");
   if (this.stateCommand || this.fileState) {
     characteristic.on("get", this.getState.bind(this));
   }
 
   if (this.fileState) {
-    const fileCreatedHandler = function (path, stats) {
+    const fileCreatedHandler = function (path) {
       if (!this.currentState) {
         this.log.info(`File "${path}" was created`);
         this.currentState = true;
@@ -140,7 +237,7 @@ script2Accessory.prototype.getServices = function () {
       }
     }.bind(this);
 
-    const fileRemovedHandler = function (path, stats) {
+    const fileRemovedHandler = function (path) {
       if (this.currentState) {
         this.log.info(`File "${path}" was deleted`);
         this.currentState = false;
@@ -148,9 +245,29 @@ script2Accessory.prototype.getServices = function () {
       }
     }.bind(this);
 
-    const watcher = chokidar.watch(this.fileState, { alwaysStat: true });
-    watcher.on("add", fileCreatedHandler);
-    watcher.on("unlink", fileRemovedHandler);
+    this.shutdown();
+    this.watcher = chokidar.watch(this.fileState, { alwaysStat: true });
+    this.watcher.on("add", fileCreatedHandler);
+    this.watcher.on("unlink", fileRemovedHandler);
   }
+};
+
+Script2DeviceLogic.prototype.buildServices = function () {
+  const informationService = new Service.AccessoryInformation();
+  const switchService = new Service.Switch(this.name);
+  const platformAccessory = {
+    getService: (svcType) => {
+      if (svcType === Service.AccessoryInformation) {
+        return informationService;
+      }
+      if (svcType === Service.Switch) {
+        return switchService;
+      }
+      return null;
+    },
+    addService: () => null,
+  };
+
+  this.bindServices(platformAccessory);
   return [informationService, switchService];
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.3.3",
+  "version": "0.3.4-beta.0",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Introduce a dynamic platform mode to allow multiple devices to be managed by a single platform configuration with cached accessories and `configureAccessory` support.
- Preserve legacy accessory mode for backward compatibility while enabling migration to platform mode.
- Improve reliability and lifecycle management of file-based state by adding proper file watcher setup and teardown.

### Description
- Register a new platform `Script2Platform` and keep legacy accessory registration using `PLUGIN_NAME`, `ACCESSORY_NAME`, and `PLATFORM_NAME` constants, and add `Script2Platform` with `configureAccessory` and `discoverDevices` logic.
- Refactor device behavior into a `Script2DeviceLogic` class that implements `setState`, `getState`, `bindServices`, `buildServices`, and `shutdown`, and use this for both platform and legacy accessory modes.
- Add chokidar-based file watching per-device with safe shutdown via `shutdown`, and track instances and cached accessories to remove stale entries during discovery.
- Improve command execution and logging for `setState`/`getState`, normalize outputs, and ensure `Characteristic` listeners are reset before attaching handlers.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7962fef0832c819a9a449e5dbe7d)