### PR TITLE
Add optional polling for `state` script and document new config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Name            | Value         | Required                                    | 
 `fileState`     | _(custom)_    | fileState or state is required (see note)   | File used as current state flag
 `state`         | _(custom)_    | fileState or state is required (see note)   | Script to determine current state
 `on_value`      | _(custom)_    | no* (default set to `"true"`)             | Value matched against `state` command output
+`polling`       | `true/false`  | no (default `false`)                       | Enables periodic polling for `state` command mode only
+`polling_interval` | integer ms | no (default `5000`)                        | Poll interval in milliseconds when `polling` is enabled
+`polling_on_start` | `true/false` | no (default `true`)                     | Immediately run a state poll when Homebridge starts
 `unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
 
 ### Platform configuration example
@@ -52,6 +55,9 @@ Name            | Value         | Required                                    | 
         "state": "/var/homebridge/rpc3control/state.sh 1",
         "fileState": "/var/homebridge/rpc3control/script1.flag",
         "on_value": "true",
+        "polling": false,
+        "polling_interval": 5000,
+        "polling_on_start": true,
         "unique_serial": "platform-1234567"
       }
     ]
@@ -63,6 +69,8 @@ Name            | Value         | Required                                    | 
 ### State script behavior
 The `state` script output is normalized to lowercase and compared against `on_value` (default `true`).
 If the script returns a non-zero exit code but still prints a valid value to stdout (for example `true` or `false`), the plugin will use stdout to determine state.
+When `polling` is enabled, the `state` script is executed on the configured interval and updates HomeKit if the value changes.
+Polling options are ignored when `fileState` is configured, since `fileState` already uses filesystem change notifications.
 
 ## Installation
 (Requires node >=6.0.0)
@@ -84,6 +92,9 @@ Name            | Value         | Required                                    | 
 `fileState`     | _(custom)_    | fileState or state is required (see note)   | Location of file that flags on or off current state. If this is configured the plugin will use the existence of this file to determine the current on or off state. If file exists, accessory is determined to be on. If file does not exist, accessory is determined to be off. This is not required. But if set, it will override using the state script. fileState or state must be configured. Use full path when setting this it's value. Do not use "~/".
 `state`         | _(custom)_    | fileState or state is required (see note)   | Location of script to execute the current state check. It must output to stdout the current state. It is not required if fileState is being used instead. fileState or state must be configured.
 `on_value`      | _(custom)_    | no* (see note, default set to "true")       | Used in conjunction with the state script. If using the state script this is the value that will be used to match against the state script output. If this value matches the output, then the accessory will be determined to be on. Required if using state script.
+`polling`       | `true/false`  | no (default `false`)                         | Enables periodic state checks when using `state` script mode (ignored when `fileState` is configured)
+`polling_interval` | integer ms | no (default `5000`)                          | Poll interval in milliseconds when `polling` is enabled
+`polling_on_start` | `true/false` | no (default `true`)                       | Immediately run a poll on startup before waiting for the interval
 `unique_serial` | _(custom)_    | no (default set to "Script2 Serial number") | If you have more than one "accessory" configured, please set unique values for each accessory. Unique values per accessory required for the Eve app.
 
 ## Configuration
@@ -138,4 +149,3 @@ Name            | Value         | Required                                    | 
 - The state.sh script in this case would be executed to check current state.  Insure that this script outputs to stdout the matching on value as configured by the on_value config parameter. If the on_value matches the on value output of this script then the accessory will be determined to be on.
 - The configured fileState file is not used in this example. Because it was not configured, the state script is being used.
 - The on_value in this case is used to match against the state script output. If the value matches the output of the state script, the accessory is determined to be on.
-

--- a/index.js
+++ b/index.js
@@ -117,9 +117,14 @@ function Script2DeviceLogic(log, config) {
   this.stateCommand = config["state"] || false;
   this.onValue = config["on_value"] || "true";
   this.fileState = config["fileState"] || false;
+  this.polling = config["polling"] || false;
+  this.pollingInterval = Number(config["polling_interval"] || 5000);
+  this.pollingOnStart =
+    config["polling_on_start"] === undefined ? true : !!config["polling_on_start"];
   this.uniqueSerial = config["unique_serial"] || "script2 Serial Number";
   this.onValue = this.onValue.trim().toLowerCase();
   this.watcher = null;
+  this.pollTimer = null;
 
   try {
     this.currentState = this.fileState ? fileExists.sync(this.fileState) : false;
@@ -130,12 +135,32 @@ function Script2DeviceLogic(log, config) {
 }
 
 Script2DeviceLogic.prototype.shutdown = function () {
+  if (this.pollTimer) {
+    clearInterval(this.pollTimer);
+    this.pollTimer = null;
+  }
+
   if (this.watcher) {
     this.watcher.close().catch((err) => {
       this.log.warn(`Error while closing file watcher for ${this.name}: ${err.message}`);
     });
     this.watcher = null;
   }
+};
+
+Script2DeviceLogic.prototype.pollStateAndUpdateCharacteristic = function (switchService) {
+  this.getState((err, poweredOn) => {
+    if (err) {
+      this.log.warn(`Polling state failed for ${this.name}: ${err.message}`);
+      return;
+    }
+
+    if (this.currentState !== poweredOn) {
+      this.currentState = poweredOn;
+      switchService.updateCharacteristic(Characteristic.On, poweredOn);
+      this.log.info(`Polled state update for ${this.name}: ${poweredOn ? "ON" : "OFF"}`);
+    }
+  });
 };
 
 Script2DeviceLogic.prototype.setState = function (powerOn, callback) {
@@ -261,6 +286,23 @@ Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
     this.watcher = chokidar.watch(this.fileState, { alwaysStat: true });
     this.watcher.on("add", fileCreatedHandler);
     this.watcher.on("unlink", fileRemovedHandler);
+  }
+
+  if (!this.fileState && this.stateCommand && this.polling) {
+    if (!Number.isFinite(this.pollingInterval) || this.pollingInterval <= 0) {
+      this.log.warn(
+        `Invalid polling_interval '${this.pollingInterval}' for ${this.name}; using default 5000ms.`
+      );
+      this.pollingInterval = 5000;
+    }
+
+    if (this.pollingOnStart) {
+      this.pollStateAndUpdateCharacteristic(switchService);
+    }
+
+    this.pollTimer = setInterval(() => {
+      this.pollStateAndUpdateCharacteristic(switchService);
+    }, this.pollingInterval);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ Script2DeviceLogic.prototype.pollStateAndUpdateCharacteristic = function (switch
 };
 
 Script2DeviceLogic.prototype.setState = function (powerOn, callback) {
-  this.log.info(`Setting ${this.name} to ${powerOn ? "ON" : "OFF"}...`);
+  this.log.debug(`Setting ${this.name} to ${powerOn ? "ON" : "OFF"}...`);
 
   const command = powerOn ? this.onCommand : this.offCommand;
   this.log.debug(`Executing command: ${command}`);
@@ -189,12 +189,12 @@ Script2DeviceLogic.prototype.setState = function (powerOn, callback) {
 };
 
 Script2DeviceLogic.prototype.getState = function (callback) {
-  this.log.info(`Getting ${this.name} state...`);
+  this.log.debug(`Getting ${this.name} state...`);
 
   if (this.fileState) {
     try {
       const poweredOn = fileExists.sync(this.fileState);
-      this.log.info(`State of ${this.name} is: ${poweredOn ? "ON" : "OFF"}`);
+      this.log.info(`Get State of ${this.name} using file flag returned: ${poweredOn ? "ON" : "OFF"}`);
       callback(null, poweredOn);
     } catch (err) {
       this.log.error(`Error checking file state: ${err.message}`);
@@ -230,7 +230,7 @@ Script2DeviceLogic.prototype.getState = function (callback) {
       }
 
       const poweredOn = cleanCommandOutput == this.onValue;
-      this.log.info(`State of ${this.name} is: ${poweredOn ? "ON" : "OFF"}`);
+      this.log.info(`State of ${this.name} using state script is: ${poweredOn ? "ON" : "OFF"}`);
       callback(null, poweredOn);
     });
     return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.3.5-beta.1",
+  "version": "0.3.5-beta.2",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.3.4-beta.1",
+  "version": "0.3.5-beta.1",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Provide an alternative to filesystem-based state detection by periodically polling the `state` script for devices that cannot reliably use `fileState`.
- Allow configuration of polling behavior such as enabling/disabling polling, interval, and an immediate startup poll via `polling`, `polling_interval`, and `polling_on_start`.
- Ensure proper cleanup of polling timers alongside existing file watcher shutdown logic to avoid orphaned timers on restart/shutdown.

### Description
- Implemented polling fields on the device logic: `polling`, `pollingInterval`, and `pollingOnStart`, and added `pollTimer` to manage the interval timer in `index.js`.
- Added `pollStateAndUpdateCharacteristic` helper that runs `getState` and updates the `Switch` characteristic only when the state changes, with informative logging on polls.
- Start polling only when `fileState` is not configured and `state` is present, with validation for `polling_interval`, an immediate poll when `polling_on_start` is true, and periodic polls via `setInterval`.
- Added shutdown logic to clear the polling timer and updated `README.md` to document the new `polling`, `polling_interval`, and `polling_on_start` options and explain their behavior and defaults.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc00dd3a24832c8943e5a461eb588d)