### PR TITLE
Add `state_cache_ttl_ms` and implement state read caching with in-flight coalescing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Name            | Value         | Required                                    | 
 `polling`       | `true/false`  | no (default `false`)                       | Enables periodic polling for `state` command mode only
 `polling_interval` | integer ms | no (default `5000`)                        | Poll interval in milliseconds when `polling` is enabled
 `polling_on_start` | `true/false` | no (default `true`)                     | Immediately run a state poll when Homebridge starts
+`state_cache_ttl_ms` | integer ms | no (default `1000`)                     | Cache TTL for `state` reads to avoid duplicate script executions on burst GET requests
 `unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
 
 ### Platform configuration example
@@ -58,6 +59,7 @@ Name            | Value         | Required                                    | 
         "polling": false,
         "polling_interval": 5000,
         "polling_on_start": true,
+        "state_cache_ttl_ms": 1000,
         "unique_serial": "platform-1234567"
       }
     ]
@@ -71,6 +73,8 @@ The `state` script output is normalized to lowercase and compared against `on_va
 If the script returns a non-zero exit code but still prints a valid value to stdout (for example `true` or `false`), the plugin will use stdout to determine state.
 When `polling` is enabled, the `state` script is executed on the configured interval and updates HomeKit if the value changes.
 Polling options are ignored when `fileState` is configured, since `fileState` already uses filesystem change notifications.
+When `state_cache_ttl_ms` is greater than `0`, `state` reads are cached briefly to prevent duplicate script executions from burst `get` requests.
+If multiple `get` requests arrive while a state command is already running, they are coalesced and share the same in-flight command result.
 
 ## Installation
 (Requires node >=6.0.0)
@@ -95,6 +99,7 @@ Name            | Value         | Required                                    | 
 `polling`       | `true/false`  | no (default `false`)                         | Enables periodic state checks when using `state` script mode (ignored when `fileState` is configured)
 `polling_interval` | integer ms | no (default `5000`)                          | Poll interval in milliseconds when `polling` is enabled
 `polling_on_start` | `true/false` | no (default `true`)                       | Immediately run a poll on startup before waiting for the interval
+`state_cache_ttl_ms` | integer ms | no (default `1000`)                         | Cache TTL for `state` reads to avoid duplicate script executions on burst GET requests
 `unique_serial` | _(custom)_    | no (default set to "Script2 Serial number") | If you have more than one "accessory" configured, please set unique values for each accessory. Unique values per accessory required for the Eve app.
 
 ## Configuration

--- a/index.js
+++ b/index.js
@@ -121,10 +121,14 @@ function Script2DeviceLogic(log, config) {
   this.pollingInterval = Number(config["polling_interval"] || 5000);
   this.pollingOnStart =
     config["polling_on_start"] === undefined ? true : !!config["polling_on_start"];
+  this.stateCacheTtlMs = Number(config["state_cache_ttl_ms"] ?? 1000);
   this.uniqueSerial = config["unique_serial"] || "script2 Serial Number";
   this.onValue = this.onValue.trim().toLowerCase();
   this.watcher = null;
   this.pollTimer = null;
+  this.lastStateRead = null;
+  this.lastStateReadAt = 0;
+  this.inFlightStateCallbacks = null;
 
   try {
     this.currentState = this.fileState ? fileExists.sync(this.fileState) : false;
@@ -204,9 +208,36 @@ Script2DeviceLogic.prototype.getState = function (callback) {
   }
 
   if (this.stateCommand) {
+    if (!Number.isFinite(this.stateCacheTtlMs) || this.stateCacheTtlMs < 0) {
+      this.log.warn(
+        `Invalid state_cache_ttl_ms '${this.stateCacheTtlMs}' for ${this.name}; using default 1000ms.`
+      );
+      this.stateCacheTtlMs = 1000;
+    }
+
+    const now = Date.now();
+    if (
+      this.stateCacheTtlMs > 0 &&
+      this.lastStateRead !== null &&
+      now - this.lastStateReadAt <= this.stateCacheTtlMs
+    ) {
+      this.log.debug(`State get for ${this.name} served from TTL cache.`);
+      callback(null, this.lastStateRead);
+      return;
+    }
+
+    if (this.inFlightStateCallbacks) {
+      this.log.debug(`State get for ${this.name} served from in-flight request.`);
+      this.inFlightStateCallbacks.push(callback);
+      return;
+    }
+
+    this.inFlightStateCallbacks = [callback];
     const command = this.stateCommand;
     this.log.debug(`Executing command: ${command}`);
     exec(command, (error, stdout, stderr) => {
+      const pendingCallbacks = this.inFlightStateCallbacks || [];
+      this.inFlightStateCallbacks = null;
       const cleanCommandOutput = stdout.trim().toLowerCase();
       this.log.debug(`Get State Command returned ${cleanCommandOutput}`);
 
@@ -219,7 +250,7 @@ Script2DeviceLogic.prototype.getState = function (callback) {
           ? error.message
           : "Get State command returned empty output.";
         this.log.error(`Get State returned an error: ${errMessage}`);
-        callback(new Error(errMessage), null);
+        pendingCallbacks.forEach((cb) => cb(new Error(errMessage), null));
         return;
       }
 
@@ -231,7 +262,9 @@ Script2DeviceLogic.prototype.getState = function (callback) {
 
       const poweredOn = cleanCommandOutput == this.onValue;
       this.log.info(`State of ${this.name} using state script is: ${poweredOn ? "ON" : "OFF"}`);
-      callback(null, poweredOn);
+      this.lastStateRead = poweredOn;
+      this.lastStateReadAt = Date.now();
+      pendingCallbacks.forEach((cb) => cb(null, poweredOn));
     });
     return;
   }


### PR DESCRIPTION
### Motivation
- Prevent duplicate `state` script executions during burst GET requests by caching recent reads for a short TTL.
- Coalesce concurrent `get` requests so multiple callers share an in-flight `state` command result instead of spawning duplicate processes.

### Description
- Added a new configuration property `state_cache_ttl_ms` (default `1000`) exposed in both platform and accessory README examples and docs.
- Implemented caching and request coalescing in `Script2DeviceLogic` by adding `stateCacheTtlMs`, `lastStateRead`, `lastStateReadAt`, and `inFlightStateCallbacks`, and serving cached values or queued callbacks when appropriate.
- Added validation and warnings for invalid TTL values and logging to indicate when results are served from cache or from an in-flight request; updated `exec` callback handling to notify all pending callbacks and populate the cache on success.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb6dc36bc832c8a8f8dd923638b96)