### PR TITLE
Replace file-exists with built-in fs.existsSync and remove unused deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ let Service;
 let Characteristic;
 
 const exec = require("child_process").exec;
-const fileExists = require("file-exists");
+const { existsSync } = require("fs");
 const chokidar = require("chokidar");
 
 const PLUGIN_NAME = "homebridge-script2";
@@ -137,7 +137,7 @@ function Script2DeviceLogic(log, config) {
   }
 
   try {
-    this.currentState = this.fileState ? fileExists.sync(this.fileState) : false;
+    this.currentState = this.fileState ? existsSync(this.fileState) : false;
   } catch (err) {
     this.log.error(`Error checking initial file state: ${err.message}`);
     this.currentState = false;
@@ -202,7 +202,7 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
 
   if (this.fileState) {
     try {
-      const poweredOn = fileExists.sync(this.fileState);
+      const poweredOn = existsSync(this.fileState);
       this.log.info(`GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: file-state)`);
       callback(null, poweredOn, "file-state");
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "object-assign": "^4.1.1",
-    "file-exists": "^5.0.1",
     "chokidar": "^3.3.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Remove the external `file-exists` dependency in favor of Node's built-in `fs.existsSync` to simplify dependency surface and eliminate an extra package; also remove an unused `object-assign` dependency.

### Description
- Replace `require('file-exists')` with `const { existsSync } = require('fs')` and switch calls from `fileExists.sync(...)` to `existsSync(...)` in `index.js`, and remove `file-exists` and `object-assign` from `package.json` dependencies.

### Testing
- No automated tests are defined in the repository (`npm test` is not configured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf2c244e4832c9e2c95cda9241f97)