### PR TITLE
chore: upgrade chokidar to 5.0.0 and require Node.js >=20.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Name            | Value         | Required                                    | 
 - At startup with `polling_on_start: true`, the first read for each accessory is a cache miss by design, so one state-script execution per accessory is expected before subsequent reads are served from TTL.
 
 ## Installation
-(Requires node >=6.0.0)
+(Requires Node.js >=20.19.0)
 
 1. Install homebridge using: `npm install -g homebridge`
 2. Install this plugin using: `npm install -g homebridge-script2`

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "engines": {
     "homebridge": ">=1.0.0 || ^2.0.0-beta.0",
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
-    "chokidar": "^3.3.1"
+    "chokidar": "5.0.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Move to `chokidar` v5 and require a newer Node.js runtime because the v5 release requires Node.js 20.19+ and to keep watchers up-to-date and supported.

### Description
- Updated `package.json` to set `chokidar` to `5.0.0` and raised the `node` engine field to `>=20.19.0`, and updated the README install requirement to `Node.js >=20.19.0`.

### Testing
- Verified the `package.json` and `README.md` diffs and confirmed existing `index.js` usage (`require("chokidar")` and `chokidar.watch(...)`) remains unchanged; an attempted `npm install chokidar@5.0.0 --save-exact` failed in this environment due to an npm registry policy `403` error so dependency installation/lockfile changes should be validated locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd01613b84832cb9b9339487e6c5ac)