### PR TITLE
Add Homebridge Config UI schema for Script2 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ While this fork depends on file-exists there is no need to install it seperately
 
 
 
+
+## Homebridge UI Configuration
+
+This plugin now includes a **Homebridge Config UI X** schema (`config.schema.json`) so you can add and manage `Script2Platform` devices directly from the UI instead of editing raw JSON manually.
+
+- In Homebridge UI, go to **Plugins → homebridge-script2 → Settings**.
+- Use the **Devices** list to add each Script2 switch/accessory and fill in commands/paths.
+- Save and restart Homebridge when prompted.
+
 ## Platform mode
 
 This plugin now supports **both**:

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,93 @@
+{
+  "pluginAlias": "Script2",
+  "pluginType": "both",
+  "singular": true,
+  "headerDisplay": "## homebridge-script2\nConfigure Script2 in Homebridge UI without editing JSON manually.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Platform Name",
+        "type": "string",
+        "default": "Script2",
+        "required": true,
+        "description": "Display name for this platform instance in Homebridge."
+      },
+      "devices": {
+        "title": "Devices",
+        "type": "array",
+        "description": "Define one or more Script2 accessories managed by this platform.",
+        "items": {
+          "title": "Device",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Accessory Name",
+              "type": "string",
+              "required": true
+            },
+            "on": {
+              "title": "ON Command",
+              "type": "string",
+              "required": true,
+              "placeholder": "/var/homebridge/scripts/on.sh 1"
+            },
+            "off": {
+              "title": "OFF Command",
+              "type": "string",
+              "required": true,
+              "placeholder": "/var/homebridge/scripts/off.sh 1"
+            },
+            "fileState": {
+              "title": "State File Path",
+              "type": "string",
+              "description": "If set, state is based on file existence and overrides state command.",
+              "placeholder": "/var/homebridge/scripts/device1.flag"
+            },
+            "state": {
+              "title": "State Command",
+              "type": "string",
+              "description": "Command that prints current state (for example: true/false)."
+            },
+            "on_value": {
+              "title": "ON Match Value",
+              "type": "string",
+              "default": "true",
+              "description": "State command output value interpreted as ON."
+            },
+            "polling": {
+              "title": "Enable Polling",
+              "type": "boolean",
+              "default": false,
+              "description": "Poll state command periodically (ignored when State File Path is set)."
+            },
+            "polling_interval": {
+              "title": "Polling Interval (ms)",
+              "type": "integer",
+              "default": 5000,
+              "minimum": 250
+            },
+            "polling_on_start": {
+              "title": "Poll Immediately on Startup",
+              "type": "boolean",
+              "default": true
+            },
+            "state_cache_ttl_ms": {
+              "title": "State Cache TTL (ms)",
+              "type": "integer",
+              "default": 1000,
+              "minimum": 0,
+              "description": "Short cache for burst reads to avoid duplicate command execution."
+            },
+            "unique_serial": {
+              "title": "Unique Serial",
+              "type": "string",
+              "default": "script2 Serial Number",
+              "description": "Recommended unique serial per device for HomeKit apps."
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a first-class Homebridge Config UI X configuration experience so users can add and manage Script2 devices in the UI rather than editing `config.json` by hand.
- Expose all major Script2 options (commands, file/state handling, polling, caching, serial) in a structured form to reduce configuration errors.
- Support both legacy accessory and platform usage patterns and make the plugin easier to adopt within Homebridge UI.

### Description

- Add `config.schema.json` that declares the plugin as `pluginAlias: "Script2"`, `pluginType: "both"`, and provides a `devices` array editor with device properties for `name`, `on`, `off`, `fileState`, `state`, `on_value`, `polling`, `polling_interval`, `polling_on_start`, `state_cache_ttl_ms`, and `unique_serial`.
- Mark the schema `singular: true` and include a `headerDisplay` to surface the UI form for `Script2Platform` instances.
- Update `README.md` with a new "Homebridge UI Configuration" section that documents how to open `Plugins → homebridge-script2 → Settings`, manage the `Devices` list, and save/restart Homebridge after changes.

### Testing

- Validated the schema is valid JSON using `node -e "JSON.parse(require('fs').readFileSync('config.schema.json','utf8'))"`, which succeeded.
- Smoke-tested plugin module load using `node -e "require('./index.js')"`, which succeeded.
- Performed a local content sanity check on `README.md` to ensure the new UI documentation is present and well-formed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0cff0920832c9a554ab31b603881)