### PR TITLE
Add `reset_state_cache_on_set` option to reset TTL after manual ON/OFF

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Name            | Value         | Required                                    | 
 `polling_interval` | integer ms | no (default `5000`)                        | Poll interval in milliseconds when `polling` is enabled
 `polling_on_start` | `true/false` | no (default `true`)                     | Immediately run a state poll when Homebridge starts
 `state_cache_ttl_ms` | integer ms | no (default `1000`)                     | Cache TTL for `state` reads to avoid duplicate script executions on burst GET requests
+`reset_state_cache_on_set` | `true/false` | no (default `false`)               | When enabled, successful manual ON/OFF actions reset the state cache timer and seed it with the set state
 `unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
 
 ### Platform configuration example
@@ -63,6 +64,7 @@ Name            | Value         | Required                                    | 
         "polling_interval": 5000,
         "polling_on_start": true,
         "state_cache_ttl_ms": 1000,
+        "reset_state_cache_on_set": false,
         "unique_serial": "platform-1234567"
       }
     ]
@@ -79,6 +81,7 @@ Name            | Value         | Required                                    | 
 - When `polling` is enabled, the `state` script is executed on the configured interval and updates HomeKit if the value changes.
 - Polling options are ignored when `fileState` is configured, since `fileState` already uses filesystem change notifications to dynamically update homekit status.
 - When `state_cache_ttl_ms` is greater than `0`, `state` reads are cached briefly to prevent duplicate script executions from burst `get` requests.
+- By default, manual HomeKit ON/OFF actions do **not** reset or extend `state_cache_ttl_ms`. Set `reset_state_cache_on_set` to `true` if you want successful manual set actions to reset the TTL timer and seed the cache with the newly set state.
 - If multiple `get` requests arrive while a state command is already running, they are coalesced and share the same in-flight command result.
 - Each `getState` request writes a single result log entry in the format `GetState <name>: ON/OFF (path: <homekit-get|polling>, source: <state-script|ttl-cache|in-flight-coalesced|file-state>)`. Where Path is telling you if this was the result of a polling request or a homekit initiated get request (out of the plugin's control). And source is where the value was sourced from, state-script execution result, ttl cache, in-flight coalesced, or from file-state.  
 - The TTL cache is per-accessory instance (per configured outlet/switch), not global across all accessories.

--- a/config.schema.json
+++ b/config.schema.json
@@ -79,6 +79,12 @@
               "minimum": 0,
               "description": "Short cache for burst reads to avoid duplicate command execution."
             },
+            "reset_state_cache_on_set": {
+              "title": "Reset State Cache on Manual Set",
+              "type": "boolean",
+              "default": false,
+              "description": "When enabled, successful HomeKit ON/OFF actions reset the state cache TTL to the newly set state."
+            },
             "unique_serial": {
               "title": "Unique Serial",
               "type": "string",

--- a/index.js
+++ b/index.js
@@ -122,6 +122,7 @@ function Script2DeviceLogic(log, config) {
   this.pollingOnStart =
     config["polling_on_start"] === undefined ? true : !!config["polling_on_start"];
   this.stateCacheTtlMs = Number(config["state_cache_ttl_ms"] ?? 1000);
+  this.resetStateCacheOnSet = config["reset_state_cache_on_set"] === true;
   this.uniqueSerial = config["unique_serial"] || "script2 Serial Number";
   this.onValue = this.onValue.trim().toLowerCase();
   this.watcher = null;
@@ -191,6 +192,13 @@ Script2DeviceLogic.prototype.setState = function (powerOn, callback) {
     this.log.debug(`Set State Command returned ${commandOutput}`);
 
     this.currentState = powerOn;
+    if (this.resetStateCacheOnSet && this.stateCommand && !this.fileState) {
+      this.lastStateRead = powerOn;
+      this.lastStateReadAt = Date.now();
+      this.log.debug(
+        `Reset state cache for ${this.name} from manual set action to ${powerOn ? "ON" : "OFF"}.`
+      );
+    }
     this.log.info(`Set ${this.name} to ${powerOn ? "ON" : "OFF"}`);
 
     callback(null, powerOn);


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to have manual HomeKit ON/OFF actions refresh and seed the short-lived `state` TTL cache so subsequent reads reflect the recently set state without waiting for the cache to expire.

### Description
- Add a new boolean config option `reset_state_cache_on_set` (default `false`) to `config.schema.json` and document it in `README.md` with example usage.
- Wire the option into device logic (`this.resetStateCacheOnSet = config["reset_state_cache_on_set"] === true`) in `index.js` and only apply it for devices using `state` scripts (not `fileState`).
- On successful manual `setState` command execution, when the option is enabled, update the in-memory TTL cache (`lastStateRead` and `lastStateReadAt`) and emit a debug log showing the cache reset.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4ca10ab4832cb20117fe88e7f5a8)