### PR TITLE
Make Homebridge UI schema platform-only and update README to clarify modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ This plugin now includes a **Homebridge Config UI X** schema (`config.schema.jso
 
 ## Platform mode
 
-This plugin now supports **both**:
-- Legacy accessory mode (backward compatible)
+This plugin runtime supports **both**:
+- Legacy accessory mode (backward compatible in manual JSON)
 - New dynamic platform mode (`Script2Platform`)
+
+Homebridge Config UI schema is now **platform-only** (dynamic platform) for reliable rich editing in UI.
 
 ### Backward compatibility
 - Existing accessory-based setups remain supported and unchanged.
@@ -72,6 +74,8 @@ Name            | Value         | Required                                    | 
 ]
 ```
 
+Type note: use JSON booleans for `polling` (for example `"polling": true`), not strings like `"polling": "true"`.
+
 
 ### State script behavior
 - The `state` script output is normalized to lowercase and compared against `on_value` (default `true`).
@@ -99,7 +103,8 @@ Name            | Value         | Required                                    | 
 ## Legacy accessory mode (still supported)
 
 Legacy `accessories` mode remains supported for backward compatibility.
-For new installs, platform mode is recommended.
+For new installs, platform mode is recommended and fully supported in Homebridge Config UI rich editing.
+Legacy accessory mode remains available as runtime backward compatibility for existing manual JSON configs.
 If you migrate from legacy accessory mode to platform mode, remove the old accessory setup and start fresh with a new `platforms` configuration.
 
 ### Legacy accessory configuration parameters

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,6 +1,6 @@
 {
-  "pluginAlias": "Script2",
-  "pluginType": "both",
+  "pluginAlias": "Script2Platform",
+  "pluginType": "platform",
   "singular": true,
   "headerDisplay": "## homebridge-script2\nConfigure Script2 in Homebridge UI without editing JSON manually.",
   "schema": {


### PR DESCRIPTION
### Motivation
- Clarify UI configuration and platform vs accessory usage so users can manage devices in Homebridge Config UI X instead of editing raw JSON.
- Ensure the UI schema reflects the intended runtime behavior and reduces confusion about adding devices via the UI.
- Document backward compatibility and runtime behavior for legacy accessory configs while recommending platform usage.

### Description
- Updated `README.md` to document the new Homebridge Config UI X schema, explain platform mode usage, and clarify that the plugin runtime supports both legacy accessory mode and the new dynamic `Script2Platform` platform mode.
- Made the UI schema platform-only by changing `config.schema.json` values to `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb77c25f8832c85d3a9e2e7ecc6cb)