### PR TITLE
Add `fail_on_state_exit_code` option and HomeKit fault reporting for state reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Name            | Value         | Required                                    | 
 `polling_on_start` | `true/false` | no (default `true`)                     | Immediately run a state poll when Homebridge starts
 `state_cache_ttl_ms` | integer ms | no (default `1000`)                     | Cache TTL for `state` reads to avoid duplicate script executions on burst GET requests
 `reset_state_cache_on_set` | `true/false` | no (default `false`)               | When enabled, successful manual ON/OFF actions reset the state cache timer and seed it with the set state
+`fail_on_state_exit_code` | `true/false` | no (default `false`)               | When enabled, non-zero exit code from the `state` command is treated as an error and the accessory is marked with a fault
 `unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
 
 ### Platform configuration example
@@ -67,6 +68,7 @@ Name            | Value         | Required                                    | 
         "polling_on_start": true,
         "state_cache_ttl_ms": 1000,
         "reset_state_cache_on_set": false,
+        "fail_on_state_exit_code": false,
         "unique_serial": "platform-1234567"
       }
     ]
@@ -82,6 +84,10 @@ Type note: use JSON booleans for `polling` (for example `"polling": true`), not 
 - If both `fileState` and `state` are configured, `fileState` takes precedence: the state script is not used for status changes and the configured file flag is used instead.
 - If using fileState your on and off scripts should create the fileState file and delete the fileState file for homekit to see the changes.
 - If a script returns a non-zero exit code but still prints a valid value to stdout (for example `true` or `false`), the plugin will use stdout to determine state.
+- To keep this behavior as default, `fail_on_state_exit_code` is `false` by default. Set it to `true` to treat non-zero state script exit codes as errors.
+- When `fail_on_state_exit_code` is enabled and the state script exits non-zero, the get request returns an error and the accessory is marked with a HomeKit fault (unreachable/problem state) until state reads succeed again.
+- `fileState` checks also participate in fault reporting: if reading the configured path throws an error, the accessory is marked with a HomeKit fault (unreachable/problem state) until reads succeed again.
+- On successful `fileState` or `state` reads, the HomeKit fault is cleared automatically.
 - When `polling` is enabled, the `state` script is executed on the configured interval and updates HomeKit if the value changes.
 - Polling options are ignored when `fileState` is configured, since `fileState` already uses filesystem change notifications to dynamically update homekit status.
 - When `state_cache_ttl_ms` is greater than `0`, `state` reads are cached briefly to prevent duplicate script executions from burst `get` requests.

--- a/config.schema.json
+++ b/config.schema.json
@@ -92,6 +92,12 @@
               "default": false,
               "description": "When enabled, successful HomeKit ON/OFF actions reset the state cache TTL to the newly set state."
             },
+            "fail_on_state_exit_code": {
+              "title": "Fail on Non-zero State Exit Code",
+              "type": "boolean",
+              "default": false,
+              "description": "When enabled, a non-zero exit code from the state command is treated as an error and the accessory is marked with a fault until reads recover."
+            },
             "unique_serial": {
               "title": "Unique Serial",
               "type": "string",

--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ function Script2DeviceLogic(log, config) {
     config["polling_on_start"] === undefined ? true : !!config["polling_on_start"];
   this.stateCacheTtlMs = Number(config["state_cache_ttl_ms"] ?? 1000);
   this.resetStateCacheOnSet = config["reset_state_cache_on_set"] === true;
+  this.failOnStateExitCode = config["fail_on_state_exit_code"] === true;
   this.uniqueSerial = config["unique_serial"] || "script2 Serial Number";
   this.onValue = this.onValue.trim().toLowerCase();
   this.watcher = null;
@@ -130,6 +131,7 @@ function Script2DeviceLogic(log, config) {
   this.lastStateRead = null;
   this.lastStateReadAt = 0;
   this.inFlightStateCallbacks = null;
+  this.switchService = null;
 
   if (this.fileState && this.stateCommand) {
     this.log.warn(
@@ -162,10 +164,12 @@ Script2DeviceLogic.prototype.shutdown = function () {
 Script2DeviceLogic.prototype.pollStateAndUpdateCharacteristic = function (switchService) {
   this.getState((err, poweredOn) => {
     if (err) {
+      this.updateReachabilityFault(true);
       this.log.warn(`Polling state failed for ${this.name}: ${err.message}`);
       return;
     }
 
+    this.updateReachabilityFault(false);
     if (this.currentState !== poweredOn) {
       this.currentState = poweredOn;
       switchService.updateCharacteristic(Characteristic.On, poweredOn);
@@ -212,9 +216,11 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
     try {
       const poweredOn = existsSync(this.fileState);
       this.log.info(`GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: file-state)`);
+      this.updateReachabilityFault(false);
       callback(null, poweredOn, "file-state");
     } catch (err) {
       this.log.error(`Error checking file state: ${err.message}`);
+      this.updateReachabilityFault(true);
       callback(err, null);
     }
     return;
@@ -235,6 +241,7 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
       now - this.lastStateReadAt <= this.stateCacheTtlMs
     ) {
       this.log.info(`GetState ${this.name}: ${this.lastStateRead ? "ON" : "OFF"} (path: ${requestPath}, source: ttl-cache)`);
+      this.updateReachabilityFault(false);
       callback(null, this.lastStateRead, "ttl-cache");
       return;
     }
@@ -243,11 +250,13 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
       this.log.debug(`State get for ${this.name} served from in-flight request.`);
       this.inFlightStateCallbacks.push((err, poweredOn, source) => {
         if (err) {
+          this.updateReachabilityFault(true);
           callback(err, null, source);
           return;
         }
 
         this.log.info(`GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: in-flight-coalesced)`);
+        this.updateReachabilityFault(false);
         callback(null, poweredOn, "in-flight-coalesced");
       });
       return;
@@ -271,11 +280,19 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
           ? error.message
           : "Get State command returned empty output.";
         this.log.error(`Get State returned an error: ${errMessage}`);
+        this.updateReachabilityFault(true);
         pendingCallbacks.forEach((cb) => cb(new Error(errMessage), null));
         return;
       }
 
       if (error) {
+        if (this.failOnStateExitCode) {
+          const errMessage = `Get State command exited non-zero (${error.code ?? "unknown"}): ${error.message}`;
+          this.log.error(errMessage);
+          this.updateReachabilityFault(true);
+          pendingCallbacks.forEach((cb) => cb(new Error(errMessage), null));
+          return;
+        }
         this.log.warn(
           `Get State command exited non-zero (${error.code ?? "unknown"}) but returned stdout; using stdout for state.`
         );
@@ -283,6 +300,7 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
 
       const poweredOn = cleanCommandOutput == this.onValue;
       this.log.info(`GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: state-script)`);
+      this.updateReachabilityFault(false);
       this.lastStateRead = poweredOn;
       this.lastStateReadAt = Date.now();
       pendingCallbacks.forEach((cb) => cb(null, poweredOn, "state-script"));
@@ -302,6 +320,7 @@ Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
   const switchService =
     platformAccessory.getService(Service.Switch) ||
     platformAccessory.addService(Service.Switch, this.name);
+  this.switchService = switchService;
 
   const theSerial = this.uniqueSerial.toString();
 
@@ -358,6 +377,17 @@ Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
       this.pollStateAndUpdateCharacteristic(switchService);
     }, this.pollingInterval);
   }
+};
+
+Script2DeviceLogic.prototype.updateReachabilityFault = function (hasFault) {
+  if (!this.switchService) {
+    return;
+  }
+
+  this.switchService.updateCharacteristic(
+    Characteristic.StatusFault,
+    hasFault ? Characteristic.StatusFault.GENERAL_FAULT : Characteristic.StatusFault.NO_FAULT
+  );
 };
 
 Script2DeviceLogic.prototype.buildServices = function () {


### PR DESCRIPTION
### Motivation
- Provide an option to treat non-zero exit codes from the configured `state` command as errors instead of silently using stdout. 
- Surface state-read failures (script errors or file read errors) to HomeKit by marking the accessory with a fault so UIs show reachability problems. 
- Improve observability by clearing the fault on successful reads and reporting faults during polling and coalesced/in-flight reads.

### Description
- Added a new boolean config option `fail_on_state_exit_code` in `config.schema.json` and documented it in `README.md` to control whether non-zero `state` command exit codes are treated as errors. 
- Implemented fault reporting in `index.js` by storing the service reference, adding `updateReachabilityFault(hasFault)`, and invoking it on file-state errors, state-command errors (including when `fail_on_state_exit_code` is enabled), polling failures, and to clear faults on successful reads. 
- Enhanced `getState` and polling paths to update the `StatusFault` characteristic and to respect the new `failOnStateExitCode` flag while preserving existing behavior (using stdout on non-zero exit code) when the flag is `false`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000502bd04832cb1387e0bc62b392e)