### PR TITLE
Improve state command diagnostics and handling; avoid writing StatusFault; version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Name            | Value         | Required                                    | 
 `polling_on_start` | `true/false` | no (default `true`)                     | Immediately run a state poll when Homebridge starts
 `state_cache_ttl_ms` | integer ms | no (default `1000`)                     | Cache TTL for `state` reads to avoid duplicate script executions on burst GET requests
 `reset_state_cache_on_set` | `true/false` | no (default `false`)               | When enabled, successful manual ON/OFF actions reset the state cache timer and seed it with the set state
-`fail_on_state_exit_code` | `true/false` | no (default `false`)               | When enabled, non-zero exit code from the `state` command is treated as an error and the accessory is marked with a fault
+`fail_on_state_exit_code` | `true/false` | no (default `false`)               | When enabled, non-zero exit code from the `state` command is treated as an error for that read request
 `unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
 
 ### Platform configuration example
@@ -83,11 +83,15 @@ Type note: use JSON booleans for `polling` (for example `"polling": true`), not 
 - The `state` script output is normalized to lowercase and compared against `on_value` (default `true`).
 - If both `fileState` and `state` are configured, `fileState` takes precedence: the state script is not used for status changes and the configured file flag is used instead.
 - If using fileState your on and off scripts should create the fileState file and delete the fileState file for homekit to see the changes.
-- If a script returns a non-zero exit code but still prints a valid value to stdout (for example `true` or `false`), the plugin will use stdout to determine state.
+- If a script returns a non-zero exit code but still prints a valid value to stdout (for example `true` or `false`), the plugin will use stdout to determine state and log a warning with exit/stderr details.
 - To keep this behavior as default, `fail_on_state_exit_code` is `false` by default. Set it to `true` to treat non-zero state script exit codes as errors.
-- When `fail_on_state_exit_code` is enabled and the state script exits non-zero, the get request returns an error and the accessory is marked with a HomeKit fault (unreachable/problem state) until state reads succeed again.
-- `fileState` checks also participate in fault reporting: if reading the configured path throws an error, the accessory is marked with a HomeKit fault (unreachable/problem state) until reads succeed again.
-- On successful `fileState` or `state` reads, the HomeKit fault is cleared automatically.
+- When `fail_on_state_exit_code` is enabled and the state script exits non-zero, the get request returns an error for that read request. In Home app this may appear as a temporary "No Response" / unavailable read when HomeKit requests state.
+- `fileState` checks also return read errors if checking the configured path throws.
+- This plugin does not attach HomeKit `StatusFault` to `Switch` services, which avoids unsupported-characteristic warnings in Homebridge logs.
+- Script best practice:
+  - Print only the state token (for example `true` or `false`) to `stdout`.
+  - Print diagnostics/errors to `stderr`.
+  - Use non-zero exit codes to indicate failures; the plugin logs detailed diagnostics with device name, action (`state`/`on`/`off`), exit code, stdout, stderr, and error message.
 - When `polling` is enabled, the `state` script is executed on the configured interval and updates HomeKit if the value changes.
 - Polling options are ignored when `fileState` is configured, since `fileState` already uses filesystem change notifications to dynamically update homekit status.
 - When `state_cache_ttl_ms` is greater than `0`, `state` reads are cached briefly to prevent duplicate script executions from burst `get` requests.

--- a/index.js
+++ b/index.js
@@ -147,6 +147,22 @@ function Script2DeviceLogic(log, config) {
   }
 }
 
+Script2DeviceLogic.prototype.formatCommandDiagnostics = function (
+  action,
+  command,
+  error,
+  stdout,
+  stderr
+) {
+  const exitCode = error?.code ?? 0;
+  const signal = error?.signal ? `, signal=${error.signal}` : "";
+  const errorMessage = error?.message ?? "none";
+  const trimmedStdout = (stdout ?? "").trim();
+  const trimmedStderr = (stderr ?? "").trim();
+
+  return `${this.name} ${action} command diagnostics: exitCode=${exitCode}${signal}, errorMessage="${errorMessage}", stdout="${trimmedStdout}", stderr="${trimmedStderr}", command="${command}"`;
+};
+
 Script2DeviceLogic.prototype.shutdown = function () {
   if (this.pollTimer) {
     clearInterval(this.pollTimer);
@@ -162,11 +178,15 @@ Script2DeviceLogic.prototype.shutdown = function () {
 };
 
 Script2DeviceLogic.prototype.pollStateAndUpdateCharacteristic = function (switchService) {
-  this.getState((err, poweredOn) => {
+  this.getState((err, poweredOn, source, nonFatalError) => {
     if (err) {
       this.updateReachabilityFault(true);
       this.log.warn(`Polling state failed for ${this.name}: ${err.message}`);
       return;
+    }
+
+    if (nonFatalError) {
+      this.log.warn(`Polling state warning for ${this.name}: ${nonFatalError.message}`);
     }
 
     this.updateReachabilityFault(false);
@@ -181,12 +201,12 @@ Script2DeviceLogic.prototype.setState = function (powerOn, callback) {
   this.log.debug(`Setting ${this.name} to ${powerOn ? "ON" : "OFF"}...`);
 
   const command = powerOn ? this.onCommand : this.offCommand;
+  const action = powerOn ? "on" : "off";
   this.log.debug(`Executing command: ${command}`);
   exec(command, (error, stdout, stderr) => {
     if (error || stderr) {
-      const errMessage = stderr
-        ? `${stderr} (${error?.message ?? "unknown error"})`
-        : `${error?.message ?? "unknown error"}`;
+      const diagnostics = this.formatCommandDiagnostics(action, command, error, stdout, stderr);
+      const errMessage = `Set State returned an error. ${diagnostics}`;
       this.log.error(`Set State returned an error: ${errMessage}`);
       callback(new Error(errMessage), null);
       return;
@@ -276,8 +296,9 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
       }
 
       if (!cleanCommandOutput) {
+        const diagnostics = this.formatCommandDiagnostics("state", command, error, stdout, stderr);
         const errMessage = error
-          ? error.message
+          ? `Get State command returned empty output. ${diagnostics}`
           : "Get State command returned empty output.";
         this.log.error(`Get State returned an error: ${errMessage}`);
         this.updateReachabilityFault(true);
@@ -285,17 +306,20 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
         return;
       }
 
+      let nonFatalStateError = null;
       if (error) {
         if (this.failOnStateExitCode) {
-          const errMessage = `Get State command exited non-zero (${error.code ?? "unknown"}): ${error.message}`;
+          const diagnostics = this.formatCommandDiagnostics("state", command, error, stdout, stderr);
+          const errMessage = `Get State command exited non-zero and fail_on_state_exit_code is enabled. ${diagnostics}`;
           this.log.error(errMessage);
           this.updateReachabilityFault(true);
           pendingCallbacks.forEach((cb) => cb(new Error(errMessage), null));
           return;
         }
-        this.log.warn(
-          `Get State command exited non-zero (${error.code ?? "unknown"}) but returned stdout; using stdout for state.`
-        );
+        const diagnostics = this.formatCommandDiagnostics("state", command, error, stdout, stderr);
+        const errMessage = `Get State command exited non-zero but returned stdout; using stdout for state. ${diagnostics}`;
+        nonFatalStateError = new Error(errMessage);
+        this.log.warn(errMessage);
       }
 
       const poweredOn = cleanCommandOutput == this.onValue;
@@ -303,7 +327,7 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
       this.updateReachabilityFault(false);
       this.lastStateRead = poweredOn;
       this.lastStateReadAt = Date.now();
-      pendingCallbacks.forEach((cb) => cb(null, poweredOn, "state-script"));
+      pendingCallbacks.forEach((cb) => cb(null, poweredOn, "state-script", nonFatalStateError));
     });
     return;
   }
@@ -380,14 +404,12 @@ Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
 };
 
 Script2DeviceLogic.prototype.updateReachabilityFault = function (hasFault) {
-  if (!this.switchService) {
-    return;
-  }
-
-  this.switchService.updateCharacteristic(
-    Characteristic.StatusFault,
-    hasFault ? Characteristic.StatusFault.GENERAL_FAULT : Characteristic.StatusFault.NO_FAULT
-  );
+  // Intentionally no-op for Switch accessories.
+  // HomeKit does not define StatusFault as a supported characteristic for Service.Switch,
+  // so writing it causes Homebridge to log warnings.
+  // State-read errors are still propagated through callback errors and can surface to clients
+  // as transient read failures (for example temporary "No Response" moments).
+  void hasFault;
 };
 
 Script2DeviceLogic.prototype.buildServices = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.4.2-beta.1",
+  "version": "0.4.2-beta.3",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Make script execution failures more observable by logging full diagnostics for `state`, `on`, and `off` commands. 
- Preserve existing behavior where `state` stdout can be used despite non-zero exit codes while allowing an opt-in strict mode via `fail_on_state_exit_code`.
- Avoid writing HomeKit `StatusFault` on `Switch` services to prevent unsupported-characteristic warnings in Homebridge logs.

### Description
- Added `formatCommandDiagnostics` helper to build unified diagnostics strings containing `exitCode`, `signal`, `errorMessage`, `stdout`, `stderr`, and the executed `command`.
- Improved error handling and logging for `setState` and `getState` to include full diagnostics and to return a non-fatal error object for `getState` when a state command exits non-zero but returns usable stdout; strict behavior is enforced when `fail_on_state_exit_code` is `true`.
- Propagated a `nonFatalError` from `getState` to callers and log it during polling flows, and coalesced in-flight callbacks now receive the same diagnostic info.
- Turned `updateReachabilityFault` into an intentional no-op for `Switch` accessories and documented why writing `StatusFault` is avoided; updated `README.md` to document behavior changes, script best-practices, and to clarify how `fail_on_state_exit_code` affects read results.
- Bumped package version from `0.4.2-beta.1` to `0.4.2-beta.3`.

### Testing
- No automated tests were run because the repository contains no configured test scripts (confirmed by running `npm test`, which reports no tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00117a996c832c8731811d45b7d960)