### PR TITLE
Improve state script diagnostics, logging and fault behavior; bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Name            | Value         | Required                                    | 
 `polling_on_start` | `true/false` | no (default `true`)                     | Immediately run a state poll when Homebridge starts
 `state_cache_ttl_ms` | integer ms | no (default `1000`)                     | Cache TTL for `state` reads to avoid duplicate script executions on burst GET requests
 `reset_state_cache_on_set` | `true/false` | no (default `false`)               | When enabled, successful manual ON/OFF actions reset the state cache timer and seed it with the set state
-`fail_on_state_exit_code` | `true/false` | no (default `false`)               | When enabled, non-zero exit code from the `state` command is treated as an error and the accessory is marked with a fault
+`fail_on_state_exit_code` | `true/false` | no (default `false`)               | When enabled, non-zero exit code from the `state` command is treated as an error for that read request
 `unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
 
 ### Platform configuration example
@@ -83,17 +83,24 @@ Type note: use JSON booleans for `polling` (for example `"polling": true`), not 
 - The `state` script output is normalized to lowercase and compared against `on_value` (default `true`).
 - If both `fileState` and `state` are configured, `fileState` takes precedence: the state script is not used for status changes and the configured file flag is used instead.
 - If using fileState your on and off scripts should create the fileState file and delete the fileState file for homekit to see the changes.
-- If a script returns a non-zero exit code but still prints a valid value to stdout (for example `true` or `false`), the plugin will use stdout to determine state.
+- If a script returns a non-zero exit code but still prints a valid value to stdout (for example `true` or `false`), the plugin will use stdout to determine state and log a warning with exit/stderr details.
 - To keep this behavior as default, `fail_on_state_exit_code` is `false` by default. Set it to `true` to treat non-zero state script exit codes as errors.
-- When `fail_on_state_exit_code` is enabled and the state script exits non-zero, the get request returns an error and the accessory is marked with a HomeKit fault (unreachable/problem state) until state reads succeed again.
-- `fileState` checks also participate in fault reporting: if reading the configured path throws an error, the accessory is marked with a HomeKit fault (unreachable/problem state) until reads succeed again.
-- On successful `fileState` or `state` reads, the HomeKit fault is cleared automatically.
+- When `fail_on_state_exit_code` is enabled and the state script exits non-zero, the get request returns an error for that read request. In Home app this may appear as a temporary "No Response" / unavailable read when HomeKit requests state.
+- `fileState` checks also return read errors if checking the configured path throws.
+- This plugin does not attach HomeKit `StatusFault` to `Switch` services, which avoids unsupported-characteristic warnings in Homebridge logs.
+- Script best practice:
+  - Print only the state token (for example `true` or `false`) to `stdout`.
+  - Print diagnostics/errors to `stderr`.
+  - Use non-zero exit codes to indicate failures; the plugin logs detailed diagnostics with device name, action (`state`/`on`/`off`), exit code, stdout, stderr, and error message.
 - When `polling` is enabled, the `state` script is executed on the configured interval and updates HomeKit if the value changes.
 - Polling options are ignored when `fileState` is configured, since `fileState` already uses filesystem change notifications to dynamically update homekit status.
 - When `state_cache_ttl_ms` is greater than `0`, `state` reads are cached briefly to prevent duplicate script executions from burst `get` requests.
 - By default, manual HomeKit ON/OFF actions do **not** reset or extend `state_cache_ttl_ms`. Set `reset_state_cache_on_set` to `true` if you want successful manual set actions to reset the TTL timer and seed the cache with the newly set state.
 - If multiple `get` requests arrive while a state command is already running, they are coalesced and share the same in-flight command result.
-- Each `getState` request writes a single result log entry in the format `GetState <name>: ON/OFF (path: <homekit-get|polling>, source: <state-script|ttl-cache|in-flight-coalesced|file-state>)`. Where Path is telling you if this was the result of a polling request or a homekit initiated get request (out of the plugin's control). And source is where the value was sourced from, state-script execution result, ttl cache, in-flight coalesced, or from file-state.  
+- Each `getState` request writes a single result log entry in the format `GetState <name>: ON/OFF (path: <homekit-get|polling>, source: <state-script|ttl-cache|in-flight-coalesced|file-state>)`.
+  - For normal successful reads, this message is logged at debug level.
+  - If a state script exits non-zero but stdout is still accepted for state (`fail_on_state_exit_code: false`), this message is logged at info level.
+  - Path indicates if the read came from a HomeKit get or polling; source indicates where the value came from.
 - The TTL cache is per-accessory instance (per configured outlet/switch), not global across all accessories.
 - At startup with `polling_on_start: true`, the first read for each accessory is a cache miss by design, so one state-script execution per accessory is expected before subsequent reads are served from TTL.
 

--- a/index.js
+++ b/index.js
@@ -147,6 +147,22 @@ function Script2DeviceLogic(log, config) {
   }
 }
 
+Script2DeviceLogic.prototype.formatCommandDiagnostics = function (
+  action,
+  command,
+  error,
+  stdout,
+  stderr
+) {
+  const exitCode = error?.code ?? 0;
+  const signal = error?.signal ? `, signal=${error.signal}` : "";
+  const errorMessage = error?.message ?? "none";
+  const trimmedStdout = (stdout ?? "").trim();
+  const trimmedStderr = (stderr ?? "").trim();
+
+  return `${this.name} ${action} command diagnostics: exitCode=${exitCode}${signal}, errorMessage="${errorMessage}", stdout="${trimmedStdout}", stderr="${trimmedStderr}", command="${command}"`;
+};
+
 Script2DeviceLogic.prototype.shutdown = function () {
   if (this.pollTimer) {
     clearInterval(this.pollTimer);
@@ -161,12 +177,26 @@ Script2DeviceLogic.prototype.shutdown = function () {
   }
 };
 
+Script2DeviceLogic.prototype.logGetStateResult = function (poweredOn, requestPath, source, nonZeroExit) {
+  const message = `GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: ${source})`;
+  if (nonZeroExit) {
+    this.log.info(message);
+    return;
+  }
+
+  this.log.debug(message);
+};
+
 Script2DeviceLogic.prototype.pollStateAndUpdateCharacteristic = function (switchService) {
-  this.getState((err, poweredOn) => {
+  this.getState((err, poweredOn, source, nonFatalError) => {
     if (err) {
       this.updateReachabilityFault(true);
       this.log.warn(`Polling state failed for ${this.name}: ${err.message}`);
       return;
+    }
+
+    if (nonFatalError) {
+      this.log.warn(`Polling state warning for ${this.name}: ${nonFatalError.message}`);
     }
 
     this.updateReachabilityFault(false);
@@ -181,12 +211,12 @@ Script2DeviceLogic.prototype.setState = function (powerOn, callback) {
   this.log.debug(`Setting ${this.name} to ${powerOn ? "ON" : "OFF"}...`);
 
   const command = powerOn ? this.onCommand : this.offCommand;
+  const action = powerOn ? "on" : "off";
   this.log.debug(`Executing command: ${command}`);
   exec(command, (error, stdout, stderr) => {
     if (error || stderr) {
-      const errMessage = stderr
-        ? `${stderr} (${error?.message ?? "unknown error"})`
-        : `${error?.message ?? "unknown error"}`;
+      const diagnostics = this.formatCommandDiagnostics(action, command, error, stdout, stderr);
+      const errMessage = `Set State returned an error. ${diagnostics}`;
       this.log.error(`Set State returned an error: ${errMessage}`);
       callback(new Error(errMessage), null);
       return;
@@ -215,7 +245,7 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
   if (this.fileState) {
     try {
       const poweredOn = existsSync(this.fileState);
-      this.log.info(`GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: file-state)`);
+      this.logGetStateResult(poweredOn, requestPath, "file-state", false);
       this.updateReachabilityFault(false);
       callback(null, poweredOn, "file-state");
     } catch (err) {
@@ -240,7 +270,7 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
       this.lastStateRead !== null &&
       now - this.lastStateReadAt <= this.stateCacheTtlMs
     ) {
-      this.log.info(`GetState ${this.name}: ${this.lastStateRead ? "ON" : "OFF"} (path: ${requestPath}, source: ttl-cache)`);
+      this.logGetStateResult(this.lastStateRead, requestPath, "ttl-cache", false);
       this.updateReachabilityFault(false);
       callback(null, this.lastStateRead, "ttl-cache");
       return;
@@ -255,7 +285,7 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
           return;
         }
 
-        this.log.info(`GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: in-flight-coalesced)`);
+        this.logGetStateResult(poweredOn, requestPath, "in-flight-coalesced", false);
         this.updateReachabilityFault(false);
         callback(null, poweredOn, "in-flight-coalesced");
       });
@@ -276,8 +306,9 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
       }
 
       if (!cleanCommandOutput) {
+        const diagnostics = this.formatCommandDiagnostics("state", command, error, stdout, stderr);
         const errMessage = error
-          ? error.message
+          ? `Get State command returned empty output. ${diagnostics}`
           : "Get State command returned empty output.";
         this.log.error(`Get State returned an error: ${errMessage}`);
         this.updateReachabilityFault(true);
@@ -285,25 +316,28 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
         return;
       }
 
+      let nonFatalStateError = null;
       if (error) {
         if (this.failOnStateExitCode) {
-          const errMessage = `Get State command exited non-zero (${error.code ?? "unknown"}): ${error.message}`;
+          const diagnostics = this.formatCommandDiagnostics("state", command, error, stdout, stderr);
+          const errMessage = `Get State command exited non-zero and fail_on_state_exit_code is enabled. ${diagnostics}`;
           this.log.error(errMessage);
           this.updateReachabilityFault(true);
           pendingCallbacks.forEach((cb) => cb(new Error(errMessage), null));
           return;
         }
-        this.log.warn(
-          `Get State command exited non-zero (${error.code ?? "unknown"}) but returned stdout; using stdout for state.`
-        );
+        const diagnostics = this.formatCommandDiagnostics("state", command, error, stdout, stderr);
+        const errMessage = `Get State command exited non-zero but returned stdout; using stdout for state. ${diagnostics}`;
+        nonFatalStateError = new Error(errMessage);
+        this.log.warn(errMessage);
       }
 
       const poweredOn = cleanCommandOutput == this.onValue;
-      this.log.info(`GetState ${this.name}: ${poweredOn ? "ON" : "OFF"} (path: ${requestPath}, source: state-script)`);
+      this.logGetStateResult(poweredOn, requestPath, "state-script", !!nonFatalStateError);
       this.updateReachabilityFault(false);
       this.lastStateRead = poweredOn;
       this.lastStateReadAt = Date.now();
-      pendingCallbacks.forEach((cb) => cb(null, poweredOn, "state-script"));
+      pendingCallbacks.forEach((cb) => cb(null, poweredOn, "state-script", nonFatalStateError));
     });
     return;
   }
@@ -380,14 +414,12 @@ Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
 };
 
 Script2DeviceLogic.prototype.updateReachabilityFault = function (hasFault) {
-  if (!this.switchService) {
-    return;
-  }
-
-  this.switchService.updateCharacteristic(
-    Characteristic.StatusFault,
-    hasFault ? Characteristic.StatusFault.GENERAL_FAULT : Characteristic.StatusFault.NO_FAULT
-  );
+  // Intentionally no-op for Switch accessories.
+  // HomeKit does not define StatusFault as a supported characteristic for Service.Switch,
+  // so writing it causes Homebridge to log warnings.
+  // State-read errors are still propagated through callback errors and can surface to clients
+  // as transient read failures (for example temporary "No Response" moments).
+  void hasFault;
 };
 
 Script2DeviceLogic.prototype.buildServices = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.4.2-beta.1",
+  "version": "0.4.2-beta.4",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Improve diagnostics and observability when external `state`/`on`/`off` scripts produce stderr or non-zero exit codes and make failure behavior more precise for individual read requests.
- Avoid writing unsupported HomeKit `StatusFault` for `Switch` services to eliminate spurious Homebridge warnings while still surfacing read errors to clients.

### Description
- Add `formatCommandDiagnostics` helper to consistently format exit code, signal, stdout/stderr, error message and the executed command for `state`/`on`/`off` executions.
- Add `logGetStateResult` helper to centralize `GetState` logging and emit `info` level when a read had a non-zero exit but stdout was used, otherwise `debug` for normal reads.
- Enhance `getState` to log and propagate non-fatal diagnostics when `state` command exits non-zero but stdout is accepted (when `fail_on_state_exit_code` is `false`), and to return an error for that specific read when `fail_on_state_exit_code` is `true`.
- Improve `setState` and `getState` error messages to include the formatted diagnostics and better logging of stderr/stdout cases.
- Make `updateReachabilityFault` a no-op for `Switch` accessories and document rationale to avoid writing unsupported `StatusFault` characteristics; state-read errors are still surfaced via callback errors to clients.
- Adjust polling behavior to surface non-fatal state warnings when appropriate and keep reachability handling consistent.
- Update `README.md` to document the new diagnostic logging behavior, script best practices, and clarify `fail_on_state_exit_code` semantics and logging levels.
- Bump package version from `0.4.2-beta.1` to `0.4.2-beta.4` in `package.json`.

### Testing
- No automated tests are defined in the repository, so no automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00117a996c832c8731811d45b7d960)