### PR TITLE
Add stateless trigger device type with schema, docs, and runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Name            | Value         | Required                                    | 
 `name`          | _(custom)_    | yes                                         | Name of accessory that will appear in Home app and is required
 `on`            | _(custom)_    | yes                                         | Script/command to execute the on action
 `off`           | _(custom)_    | yes                                         | Script/command to execute the off action
+
+`device_type`  | `switch/stateless` | no (default `switch`)            | `switch` = normal ON/OFF behavior, `stateless` = single-action trigger
+`trigger`      | _(custom)_         | required for `stateless` devices | Script/command to execute when stateless trigger is pressed
+`auto_reset_ms`| integer ms         | no (default `500`)               | Delay before stateless trigger resets to its default state in Home app
+`stateless_trigger_on` | `on/off` | no (default `on`) | Stateless trigger edge: `on` triggers when toggled ON; `off` triggers when toggled OFF and defaults tile to ON
 `fileState`     | _(custom)_    | fileState or state is required (see note)   | File used as current state flag
 `state`         | _(custom)_    | fileState or state is required (see note)   | Script to determine current state
 `on_value`      | _(custom)_    | no* (default set to `"true"`)             | Value matched against `state` command output
@@ -103,6 +108,27 @@ Type note: use JSON booleans for `polling` (for example `"polling": true`), not 
   - Path indicates if the read came from a HomeKit get or polling; source indicates where the value came from.
 - The TTL cache is per-accessory instance (per configured outlet/switch), not global across all accessories.
 - At startup with `polling_on_start: true`, the first read for each accessory is a cache miss by design, so one state-script execution per accessory is expected before subsequent reads are served from TTL.
+
+
+### Stateless trigger mode
+- Set `device_type` to `stateless` to create a single-action trigger accessory suitable for actions like outlet reboot.
+- In stateless mode, `trigger` runs on the configured edge via `stateless_trigger_on` (`on` by default).
+- `stateless_trigger_on: "on"`: press ON to trigger, then auto-reset to OFF.
+- `stateless_trigger_on: "off"`: press OFF to trigger, then auto-reset to ON (default tile state is ON).
+- Stateful options (`state`, `fileState`, `polling`, `on_value`) are ignored for stateless devices.
+
+Example:
+
+```json
+{
+  "name": "RPC3 Outlet 1 Reboot",
+  "device_type": "stateless",
+  "trigger": "/var/homebridge/rpc3control/reboot.sh 1",
+  "auto_reset_ms": 500,
+  "stateless_trigger_on": "off",
+  "unique_serial": "rpc3-outlet1-reboot"
+}
+```
 
 ## Installation
 (Requires Node.js >=20.19.0)

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,6 +33,59 @@
               "type": "string",
               "required": true
             },
+            "device_type": {
+              "title": "Device Type",
+              "type": "string",
+              "default": "switch",
+              "oneOf": [
+                {
+                  "title": "Switch (ON/OFF)",
+                  "enum": [
+                    "switch"
+                  ]
+                },
+                {
+                  "title": "Stateless Trigger (single action)",
+                  "enum": [
+                    "stateless"
+                  ]
+                }
+              ],
+              "description": "Use 'switch' for normal ON/OFF control, or 'stateless' for a single-action trigger that auto-resets OFF."
+            },
+            "trigger": {
+              "title": "Trigger Command (stateless)",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/reboot.sh 1",
+              "description": "Command executed when a stateless trigger is pressed ON."
+            },
+            "auto_reset_ms": {
+              "title": "Auto Reset Delay (ms)",
+              "type": "integer",
+              "default": 500,
+              "minimum": 0,
+              "description": "For stateless triggers, delay before the switch resets back to OFF in Home app."
+            },
+            "stateless_trigger_on": {
+              "title": "Stateless Trigger On",
+              "type": "string",
+              "default": "on",
+              "oneOf": [
+                {
+                  "title": "Trigger on ON (default)",
+                  "enum": [
+                    "on"
+                  ]
+                },
+                {
+                  "title": "Trigger on OFF (default tile ON)",
+                  "enum": [
+                    "off"
+                  ]
+                }
+              ],
+              "description": "For stateless devices, choose whether trigger runs when switching ON or OFF. OFF mode keeps tile defaulted to ON and resets back to ON after trigger."
+            },
             "on": {
               "title": "ON Command",
               "type": "string",

--- a/index.js
+++ b/index.js
@@ -114,6 +114,10 @@ function Script2DeviceLogic(log, config) {
   this.name = config["name"];
   this.onCommand = config["on"];
   this.offCommand = config["off"];
+  this.deviceType = config["device_type"] === "stateless" ? "stateless" : "switch";
+  this.triggerCommand = config["trigger"] || config["on"] || false;
+  this.autoResetMs = Number(config["auto_reset_ms"] || 500);
+  this.statelessTriggerOn = config["stateless_trigger_on"] === "off" ? "off" : "on";
   this.stateCommand = config["state"] || false;
   this.onValue = config["on_value"] || "true";
   this.fileState = config["fileState"] || false;
@@ -346,6 +350,45 @@ Script2DeviceLogic.prototype.getState = function (callback, requestPath = "homek
   callback(new Error("Must set config value for fileState or state."), null);
 };
 
+Script2DeviceLogic.prototype.setStatelessTrigger = function (powerOn, callback) {
+  const triggerOnOnAction = this.statelessTriggerOn !== "off";
+  const shouldTrigger = triggerOnOnAction ? powerOn : !powerOn;
+  const resetState = triggerOnOnAction ? false : true;
+
+  if (!shouldTrigger) {
+    callback(null, powerOn);
+    return;
+  }
+
+  const command = this.triggerCommand;
+  if (!command) {
+    callback(new Error("Missing required trigger command for stateless device."), null);
+    return;
+  }
+
+  this.log.debug(`Triggering ${this.name} stateless action...`);
+  this.log.debug(`Executing command: ${command}`);
+  exec(command, (error, stdout, stderr) => {
+    if (error || stderr) {
+      const diagnostics = this.formatCommandDiagnostics("trigger", command, error, stdout, stderr);
+      const errMessage = `Stateless trigger returned an error. ${diagnostics}`;
+      this.log.error(errMessage);
+      callback(new Error(errMessage), null);
+      return;
+    }
+
+    this.log.info(`Triggered ${this.name} stateless action`);
+    callback(null, shouldTrigger);
+
+    const resetDelay = Number.isFinite(this.autoResetMs) && this.autoResetMs >= 0 ? this.autoResetMs : 500;
+    setTimeout(() => {
+      if (this.switchService) {
+        this.switchService.updateCharacteristic(Characteristic.On, resetState);
+      }
+    }, resetDelay);
+  });
+};
+
 Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
   const informationService =
     platformAccessory.getService(Service.AccessoryInformation) ||
@@ -365,9 +408,17 @@ Script2DeviceLogic.prototype.bindServices = function (platformAccessory) {
 
   const characteristic = switchService.getCharacteristic(Characteristic.On);
   characteristic.removeAllListeners("set");
-  characteristic.on("set", this.setState.bind(this));
 
   characteristic.removeAllListeners("get");
+
+  if (this.deviceType === "stateless") {
+    characteristic.on("set", this.setStatelessTrigger.bind(this));
+    characteristic.on("get", (callback) => callback(null, this.statelessTriggerOn === "off"));
+    return;
+  }
+
+  characteristic.on("set", this.setState.bind(this));
+
   if (this.stateCommand || this.fileState) {
     characteristic.on("get", (callback) => this.getState(callback, "homekit-get"));
   }


### PR DESCRIPTION
### Motivation
- Introduce a single-action "stateless" accessory mode to support one-shot triggers (for example outlet reboot) that auto-reset in the Home app.
- Provide first-class UI schema and README documentation for configuring stateless triggers alongside existing switch mode.

### Description
- Add `device_type`, `trigger`, `auto_reset_ms`, and `stateless_trigger_on` to `config.schema.json` and document usage and an example in `README.md`.
- Implement runtime support in `index.js` by adding `deviceType`, `triggerCommand`, `autoResetMs`, and `statelessTriggerOn` properties and a new `setStatelessTrigger` method that executes the trigger command, logs diagnostics, and auto-resets the HomeKit tile after `auto_reset_ms`.
- Wire the new behavior into `bindServices` so `Switch` characteristics use `setStatelessTrigger` for `stateless` devices and provide an appropriate `get` default state based on `stateless_trigger_on`.
- Preserve backward compatibility by defaulting to existing `switch` behavior and falling back to `on` command if `trigger` is not provided.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a067f3f4cf0832cac14b14be892133d)