### PR TITLE
Improve stateless device handling: sanitize configs and tighten schema conditions

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -162,85 +162,85 @@
             {
               "key": "on",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "off",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "fileState",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "state",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "on_value",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_interval",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_on_start",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "state_cache_ttl_ms",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "reset_state_cache_on_set",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "fail_on_state_exit_code",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "return !model || model.device_type !== 'stateless'"
               }
             },
             {
               "key": "trigger",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "return !!model && model.device_type === 'stateless'"
               }
             },
             {
               "key": "auto_reset_ms",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "return !!model && model.device_type === 'stateless'"
               }
             },
             {
               "key": "stateless_trigger_on",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "return !!model && model.device_type === 'stateless'"
               }
             },
             "unique_serial"
@@ -265,6 +265,18 @@
                   "name",
                   "on",
                   "off"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "state"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fileState"
+                    ]
+                  }
                 ]
               }
             }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,32 @@ module.exports = function (homebridge) {
   homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, Script2Platform, true);
 };
 
+
+function sanitizeDeviceConfig(deviceConfig) {
+  const sanitized = { ...(deviceConfig || {}) };
+  const deviceType = sanitized["device_type"] === "stateless" ? "stateless" : "switch";
+
+  if (deviceType === "stateless") {
+    delete sanitized["on"];
+    delete sanitized["off"];
+    delete sanitized["fileState"];
+    delete sanitized["state"];
+    delete sanitized["on_value"];
+    delete sanitized["polling"];
+    delete sanitized["polling_interval"];
+    delete sanitized["polling_on_start"];
+    delete sanitized["state_cache_ttl_ms"];
+    delete sanitized["reset_state_cache_on_set"];
+    delete sanitized["fail_on_state_exit_code"];
+  } else {
+    delete sanitized["trigger"];
+    delete sanitized["auto_reset_ms"];
+    delete sanitized["stateless_trigger_on"];
+  }
+
+  return sanitized;
+}
+
 class Script2Platform {
   constructor(log, config, api) {
     this.log = log;
@@ -48,7 +74,8 @@ class Script2Platform {
 
     const configuredUuids = new Set();
 
-    for (const deviceConfig of devices) {
+    for (const rawDeviceConfig of devices) {
+      const deviceConfig = sanitizeDeviceConfig(rawDeviceConfig);
       const name = deviceConfig?.name;
       if (!name) {
         this.log.error("Skipping platform device with missing required 'name'.");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.4.3-beta.3",
+  "version": "0.4.3-beta.4",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and invalid configurations when device entries are missing or set as `stateless` by making form conditions robust to undefined `model` values and ensuring non-stateless devices provide a state source. 
- Avoid passing irrelevant fields to device logic by removing properties that don't apply to the chosen `device_type` so device instances always receive a clean configuration.

### Description
- Added `sanitizeDeviceConfig` to `index.js` to strip fields irrelevant to `device_type` and used it when iterating configured devices in `discoverDevices`.
- Updated `discoverDevices` to use the sanitized device config and kept existing platform accessory restore/register logic unchanged.
- Hardened the `config.schema.json` form `condition` function bodies to handle absent `model` by checking `!model` or `!!model` where appropriate.
- Tightened the schema `else` block to require `state` or `fileState` for non-stateless devices in addition to `name`, `on`, and `off`.

### Testing
- Ran `npm test` (project unit tests) and they completed successfully. 
- Ran `npm run lint` and code linting passed. 
- Validated the updated `config.schema.json` with a schema validator (`ajv`) and it validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077e4377c0832ca977b97d46703570)