### PR TITLE
Sanitize stateless device configs, improve schema conditions, and bump version

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -162,85 +162,85 @@
             {
               "key": "on",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "off",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "fileState",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "state",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "on_value",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_interval",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_on_start",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "state_cache_ttl_ms",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "reset_state_cache_on_set",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "fail_on_state_exit_code",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "trigger",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type === 'stateless'"
               }
             },
             {
               "key": "auto_reset_ms",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type === 'stateless'"
               }
             },
             {
               "key": "stateless_trigger_on",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const d=(model?.devices?.[arrayIndices?.devices])||model||{}; return d.device_type === 'stateless'"
               }
             },
             "unique_serial"
@@ -265,6 +265,18 @@
                   "name",
                   "on",
                   "off"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "state"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fileState"
+                    ]
+                  }
                 ]
               }
             }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,32 @@ module.exports = function (homebridge) {
   homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, Script2Platform, true);
 };
 
+
+function sanitizeDeviceConfig(deviceConfig) {
+  const sanitized = { ...(deviceConfig || {}) };
+  const deviceType = sanitized["device_type"] === "stateless" ? "stateless" : "switch";
+
+  if (deviceType === "stateless") {
+    delete sanitized["on"];
+    delete sanitized["off"];
+    delete sanitized["fileState"];
+    delete sanitized["state"];
+    delete sanitized["on_value"];
+    delete sanitized["polling"];
+    delete sanitized["polling_interval"];
+    delete sanitized["polling_on_start"];
+    delete sanitized["state_cache_ttl_ms"];
+    delete sanitized["reset_state_cache_on_set"];
+    delete sanitized["fail_on_state_exit_code"];
+  } else {
+    delete sanitized["trigger"];
+    delete sanitized["auto_reset_ms"];
+    delete sanitized["stateless_trigger_on"];
+  }
+
+  return sanitized;
+}
+
 class Script2Platform {
   constructor(log, config, api) {
     this.log = log;
@@ -48,7 +74,8 @@ class Script2Platform {
 
     const configuredUuids = new Set();
 
-    for (const deviceConfig of devices) {
+    for (const rawDeviceConfig of devices) {
+      const deviceConfig = sanitizeDeviceConfig(rawDeviceConfig);
       const name = deviceConfig?.name;
       if (!name) {
         this.log.error("Skipping platform device with missing required 'name'.");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.4.3-beta.3",
+  "version": "0.4.3-beta.5",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Prevent invalid UI conditions and runtime errors when device entries are nested in arrays or when `device_type` is `stateless` by making schema condition functions resilient and by removing irrelevant properties from device configs.
- Ensure non-stateless devices require either `state` or `fileState` to be provided.
- Keep package metadata current with a version bump.

### Description
- Updated `config.schema.json` to change many `form` condition `functionBody` checks to retrieve the device via `model?.devices?.[arrayIndices?.devices]` before checking `device_type`, avoiding false negatives for arrayed device entries.
- Added an `anyOf` requirement so non-stateless devices must include either `state` or `fileState` in the schema validations.
- Added `sanitizeDeviceConfig` in `index.js` which strips properties that are irrelevant for the declared `device_type` (`stateless` vs `switch`) and applied it when iterating configured devices (`rawDeviceConfig` → sanitized `deviceConfig`).
- Bumped package version in `package.json` from `0.4.3-beta.3` to `0.4.3-beta.5`.

### Testing
- No automated tests were added for these changes and no CI/unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077e4377c0832ca977b97d46703570)