### PR TITLE
Add stateless device support, config schema updates, and sanitize device configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,44 @@ Example (8 existing stateful switches in legacy `devices` list shape):
 ```
 
 
+
+### New grouped Config UI sections (recommended)
+
+You can now configure devices in two dedicated platform arrays:
+
+- `stateful_devices`: normal ON/OFF switches
+- `stateless_devices`: single-action trigger switches
+
+These are recommended for Config UI X because they avoid complex per-row field toggling.
+Legacy `devices` is still supported for backward compatibility.
+
+Example:
+
+```json
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "stateful_devices": [
+      {
+        "name": "Outlet 1",
+        "on": "/var/homebridge/rpc3control/on.sh 1",
+        "off": "/var/homebridge/rpc3control/off.sh 1",
+        "state": "/var/homebridge/rpc3control/state.sh 1"
+      }
+    ],
+    "stateless_devices": [
+      {
+        "name": "Outlet 1 Reboot",
+        "trigger": "/var/homebridge/rpc3control/reboot.sh 1",
+        "auto_reset_ms": 500,
+        "stateless_trigger_on": "off"
+      }
+    ]
+  }
+]
+```
+
 ### State script behavior
 - The `state` script output is normalized to lowercase and compared against `on_value` (default `true`).
 - If both `fileState` and `state` are configured, `fileState` takes precedence: the state script is not used for status changes and the configured file flag is used instead.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,36 @@ Name            | Value         | Required                                    | 
 Type note: use JSON booleans for `polling` (for example `"polling": true`), not strings like `"polling": "true"`.
 
 
+### Config UI behavior with existing `devices` arrays
+
+If you already have a platform config with `devices` (for example 8 existing ON/OFF switches), Config UI X will load those entries into the same **Devices** array editor.
+
+- Your existing entries remain editable and are **not** removed.
+- Each existing device appears as one item in the Devices list (using the plugin schema form for that row).
+- Saving from Config UI X preserves backward compatibility with existing `devices`-based platform configs.
+
+Example (8 existing stateful switches in legacy `devices` list shape):
+
+```json
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "devices": [
+      { "name": "Outlet 1", "on": "/opt/scripts/on.sh 1", "off": "/opt/scripts/off.sh 1", "state": "/opt/scripts/state.sh 1" },
+      { "name": "Outlet 2", "on": "/opt/scripts/on.sh 2", "off": "/opt/scripts/off.sh 2", "state": "/opt/scripts/state.sh 2" },
+      { "name": "Outlet 3", "on": "/opt/scripts/on.sh 3", "off": "/opt/scripts/off.sh 3", "state": "/opt/scripts/state.sh 3" },
+      { "name": "Outlet 4", "on": "/opt/scripts/on.sh 4", "off": "/opt/scripts/off.sh 4", "state": "/opt/scripts/state.sh 4" },
+      { "name": "Outlet 5", "on": "/opt/scripts/on.sh 5", "off": "/opt/scripts/off.sh 5", "state": "/opt/scripts/state.sh 5" },
+      { "name": "Outlet 6", "on": "/opt/scripts/on.sh 6", "off": "/opt/scripts/off.sh 6", "state": "/opt/scripts/state.sh 6" },
+      { "name": "Outlet 7", "on": "/opt/scripts/on.sh 7", "off": "/opt/scripts/off.sh 7", "state": "/opt/scripts/state.sh 7" },
+      { "name": "Outlet 8", "on": "/opt/scripts/on.sh 8", "off": "/opt/scripts/off.sh 8", "state": "/opt/scripts/state.sh 8" }
+    ]
+  }
+]
+```
+
+
 ### State script behavior
 - The `state` script output is normalized to lowercase and compared against `on_value` (default `true`).
 - If both `fileState` and `state` are configured, `fileState` takes precedence: the state script is not used for status changes and the configured file flag is used instead.
@@ -117,7 +147,7 @@ Type note: use JSON booleans for `polling` (for example `"polling": true`), not 
 - `stateless_trigger_on: "off"`: press OFF to trigger, then auto-reset to ON (default tile state is ON).
 - Stateful options (`state`, `fileState`, `polling`, `on_value`) are ignored for stateless devices.
 
-Example:
+Example (single stateless device object):
 
 ```json
 {
@@ -128,6 +158,34 @@ Example:
   "stateless_trigger_on": "off",
   "unique_serial": "rpc3-outlet1-reboot"
 }
+```
+
+Example (mixed platform with stateful + stateless in one `devices` list):
+
+```json
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "devices": [
+      {
+        "name": "Rack PDU Outlet 1",
+        "device_type": "switch",
+        "on": "/var/homebridge/rpc3control/on.sh 1",
+        "off": "/var/homebridge/rpc3control/off.sh 1",
+        "state": "/var/homebridge/rpc3control/state.sh 1",
+        "on_value": "true"
+      },
+      {
+        "name": "Rack PDU Outlet 1 Reboot",
+        "device_type": "stateless",
+        "trigger": "/var/homebridge/rpc3control/reboot.sh 1",
+        "auto_reset_ms": 500,
+        "stateless_trigger_on": "off"
+      }
+    ]
+  }
+]
 ```
 
 ## Installation

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,7 +23,7 @@
       "devices": {
         "title": "Devices",
         "type": "array",
-        "description": "Define one or more Script2 accessories managed by this platform.",
+        "description": "Legacy mixed devices list (deprecated; kept for backward compatibility).",
         "items": {
           "title": "Device",
           "type": "object",
@@ -282,7 +282,306 @@
             "name",
             "device_type"
           ]
-        }
+        },
+        "expandable": true,
+        "expanded": false
+      },
+      "stateful_devices": {
+        "title": "Stateful Switches (ON/OFF)",
+        "type": "array",
+        "description": "Recommended: configure standard ON/OFF switches here.",
+        "items": {
+          "title": "Device",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Accessory Name",
+              "type": "string",
+              "required": true
+            },
+            "on": {
+              "title": "ON Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/on.sh 1"
+            },
+            "off": {
+              "title": "OFF Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/off.sh 1"
+            },
+            "fileState": {
+              "title": "State File Path",
+              "type": "string",
+              "description": "If set, the on/off state is based on file existence and overrides state command.",
+              "placeholder": "/var/homebridge/scripts/device1.flag"
+            },
+            "state": {
+              "title": "State Command",
+              "type": "string",
+              "description": "Command that prints current state (for example: true/false)."
+            },
+            "on_value": {
+              "title": "ON Match Value",
+              "type": "string",
+              "default": "true",
+              "description": "State command output value interpreted as ON."
+            },
+            "polling": {
+              "title": "Enable Polling",
+              "type": "boolean",
+              "default": false,
+              "description": "Poll state command periodically (ignored when State File Path is set)."
+            },
+            "polling_interval": {
+              "title": "Polling Interval (ms)",
+              "type": "integer",
+              "default": 5000,
+              "minimum": 250
+            },
+            "polling_on_start": {
+              "title": "Poll Immediately on Startup",
+              "type": "boolean",
+              "default": true
+            },
+            "state_cache_ttl_ms": {
+              "title": "State Cache TTL (ms)",
+              "type": "integer",
+              "default": 1000,
+              "minimum": 0,
+              "description": "Short cache for burst reads to avoid duplicate command execution."
+            },
+            "reset_state_cache_on_set": {
+              "title": "Reset State Cache on Manual Set",
+              "type": "boolean",
+              "default": false,
+              "description": "When enabled, successful HomeKit ON/OFF actions reset the state cache TTL to the newly set state."
+            },
+            "fail_on_state_exit_code": {
+              "title": "Fail on Non-zero State Exit Code",
+              "type": "boolean",
+              "default": false,
+              "description": "When enabled, a non-zero exit code from the state command is treated as an error and the accessory is marked with a fault until reads recover."
+            },
+            "trigger": {
+              "title": "Trigger Command (stateless)",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/reboot.sh 1",
+              "description": "Command executed when a stateless trigger is pressed."
+            },
+            "auto_reset_ms": {
+              "title": "Auto Reset Delay (ms)",
+              "type": "integer",
+              "default": 500,
+              "minimum": 0,
+              "description": "For stateless triggers, delay before the switch resets back to its default tile state in Home app."
+            },
+            "stateless_trigger_on": {
+              "title": "Stateless Trigger On",
+              "type": "string",
+              "default": "on",
+              "oneOf": [
+                {
+                  "title": "Trigger on ON (default)",
+                  "enum": [
+                    "on"
+                  ]
+                },
+                {
+                  "title": "Trigger on OFF (default tile ON)",
+                  "enum": [
+                    "off"
+                  ]
+                }
+              ],
+              "description": "Choose whether trigger runs when switching ON or OFF. OFF mode keeps tile defaulted to ON and resets back to ON after trigger."
+            },
+            "unique_serial": {
+              "title": "Unique Serial",
+              "type": "string",
+              "default": "script2 Serial Number",
+              "description": "Recommended unique serial per device for HomeKit apps."
+            }
+          },
+          "form": [
+            "name",
+            "on",
+            "off",
+            "fileState",
+            "state",
+            "on_value",
+            "polling",
+            "polling_interval",
+            "polling_on_start",
+            "state_cache_ttl_ms",
+            "reset_state_cache_on_set",
+            "fail_on_state_exit_code",
+            "unique_serial"
+          ],
+          "allOf": [
+            {
+              "required": [
+                "name",
+                "on",
+                "off"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "state"
+                  ]
+                },
+                {
+                  "required": [
+                    "fileState"
+                  ]
+                }
+              ]
+            }
+          ],
+          "required": [
+            "name"
+          ]
+        },
+        "expandable": true,
+        "expanded": false
+      },
+      "stateless_devices": {
+        "title": "Stateless Triggers",
+        "type": "array",
+        "description": "Recommended: configure one-shot trigger devices here.",
+        "items": {
+          "title": "Device",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Accessory Name",
+              "type": "string",
+              "required": true
+            },
+            "on": {
+              "title": "ON Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/on.sh 1"
+            },
+            "off": {
+              "title": "OFF Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/off.sh 1"
+            },
+            "fileState": {
+              "title": "State File Path",
+              "type": "string",
+              "description": "If set, the on/off state is based on file existence and overrides state command.",
+              "placeholder": "/var/homebridge/scripts/device1.flag"
+            },
+            "state": {
+              "title": "State Command",
+              "type": "string",
+              "description": "Command that prints current state (for example: true/false)."
+            },
+            "on_value": {
+              "title": "ON Match Value",
+              "type": "string",
+              "default": "true",
+              "description": "State command output value interpreted as ON."
+            },
+            "polling": {
+              "title": "Enable Polling",
+              "type": "boolean",
+              "default": false,
+              "description": "Poll state command periodically (ignored when State File Path is set)."
+            },
+            "polling_interval": {
+              "title": "Polling Interval (ms)",
+              "type": "integer",
+              "default": 5000,
+              "minimum": 250
+            },
+            "polling_on_start": {
+              "title": "Poll Immediately on Startup",
+              "type": "boolean",
+              "default": true
+            },
+            "state_cache_ttl_ms": {
+              "title": "State Cache TTL (ms)",
+              "type": "integer",
+              "default": 1000,
+              "minimum": 0,
+              "description": "Short cache for burst reads to avoid duplicate command execution."
+            },
+            "reset_state_cache_on_set": {
+              "title": "Reset State Cache on Manual Set",
+              "type": "boolean",
+              "default": false,
+              "description": "When enabled, successful HomeKit ON/OFF actions reset the state cache TTL to the newly set state."
+            },
+            "fail_on_state_exit_code": {
+              "title": "Fail on Non-zero State Exit Code",
+              "type": "boolean",
+              "default": false,
+              "description": "When enabled, a non-zero exit code from the state command is treated as an error and the accessory is marked with a fault until reads recover."
+            },
+            "trigger": {
+              "title": "Trigger Command (stateless)",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/reboot.sh 1",
+              "description": "Command executed when a stateless trigger is pressed."
+            },
+            "auto_reset_ms": {
+              "title": "Auto Reset Delay (ms)",
+              "type": "integer",
+              "default": 500,
+              "minimum": 0,
+              "description": "For stateless triggers, delay before the switch resets back to its default tile state in Home app."
+            },
+            "stateless_trigger_on": {
+              "title": "Stateless Trigger On",
+              "type": "string",
+              "default": "on",
+              "oneOf": [
+                {
+                  "title": "Trigger on ON (default)",
+                  "enum": [
+                    "on"
+                  ]
+                },
+                {
+                  "title": "Trigger on OFF (default tile ON)",
+                  "enum": [
+                    "off"
+                  ]
+                }
+              ],
+              "description": "Choose whether trigger runs when switching ON or OFF. OFF mode keeps tile defaulted to ON and resets back to ON after trigger."
+            },
+            "unique_serial": {
+              "title": "Unique Serial",
+              "type": "string",
+              "default": "script2 Serial Number",
+              "description": "Recommended unique serial per device for HomeKit apps."
+            }
+          },
+          "form": [
+            "name",
+            "trigger",
+            "auto_reset_ms",
+            "stateless_trigger_on",
+            "unique_serial"
+          ],
+          "allOf": [
+            {
+              "required": [
+                "name",
+                "trigger"
+              ]
+            }
+          ],
+          "required": [
+            "name"
+          ]
+        },
+        "expandable": true,
+        "expanded": false
       }
     }
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -40,18 +40,15 @@
               "oneOf": [
                 {
                   "title": "Switch (ON/OFF)",
-                  "enum": [
-                    "switch"
-                  ]
+                  "const": "switch"
                 },
                 {
                   "title": "Stateless Trigger (single action)",
-                  "enum": [
-                    "stateless"
-                  ]
+                  "const": "stateless"
                 }
               ],
-              "description": "Use 'switch' for normal ON/OFF control, or 'stateless' for a single-action trigger that auto-resets OFF."
+              "description": "Use 'switch' for normal ON/OFF control, or 'stateless' for a single-action trigger that auto-resets OFF.",
+              "required": true
             },
             "on": {
               "title": "ON Command",
@@ -162,85 +159,85 @@
             {
               "key": "on",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "off",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "fileState",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "state",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "on_value",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_interval",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_on_start",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "state_cache_ttl_ms",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "reset_state_cache_on_set",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "fail_on_state_exit_code",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "trigger",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type === 'stateless'"
               }
             },
             {
               "key": "auto_reset_ms",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type === 'stateless'"
               }
             },
             {
               "key": "stateless_trigger_on",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type === 'stateless'"
               }
             },
             "unique_serial"
@@ -265,9 +262,25 @@
                   "name",
                   "on",
                   "off"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "state"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fileState"
+                    ]
+                  }
                 ]
               }
             }
+          ],
+          "required": [
+            "name",
+            "device_type"
           ]
         }
       }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,32 @@ module.exports = function (homebridge) {
   homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, Script2Platform, true);
 };
 
+
+function sanitizeDeviceConfig(deviceConfig) {
+  const sanitized = { ...(deviceConfig || {}) };
+  const deviceType = sanitized["device_type"] === "stateless" ? "stateless" : "switch";
+
+  if (deviceType === "stateless") {
+    delete sanitized["on"];
+    delete sanitized["off"];
+    delete sanitized["fileState"];
+    delete sanitized["state"];
+    delete sanitized["on_value"];
+    delete sanitized["polling"];
+    delete sanitized["polling_interval"];
+    delete sanitized["polling_on_start"];
+    delete sanitized["state_cache_ttl_ms"];
+    delete sanitized["reset_state_cache_on_set"];
+    delete sanitized["fail_on_state_exit_code"];
+  } else {
+    delete sanitized["trigger"];
+    delete sanitized["auto_reset_ms"];
+    delete sanitized["stateless_trigger_on"];
+  }
+
+  return sanitized;
+}
+
 class Script2Platform {
   constructor(log, config, api) {
     this.log = log;
@@ -48,7 +74,8 @@ class Script2Platform {
 
     const configuredUuids = new Set();
 
-    for (const deviceConfig of devices) {
+    for (const rawDeviceConfig of devices) {
+      const deviceConfig = sanitizeDeviceConfig(rawDeviceConfig);
       const name = deviceConfig?.name;
       if (!name) {
         this.log.error("Skipping platform device with missing required 'name'.");

--- a/index.js
+++ b/index.js
@@ -46,6 +46,19 @@ function sanitizeDeviceConfig(deviceConfig) {
   return sanitized;
 }
 
+
+function getConfiguredDevices(config) {
+  const legacyDevices = Array.isArray(config?.devices) ? config.devices : [];
+  const statefulDevices = Array.isArray(config?.stateful_devices)
+    ? config.stateful_devices.map((device) => ({ ...device, device_type: "switch" }))
+    : [];
+  const statelessDevices = Array.isArray(config?.stateless_devices)
+    ? config.stateless_devices.map((device) => ({ ...device, device_type: "stateless" }))
+    : [];
+
+  return [...legacyDevices, ...statefulDevices, ...statelessDevices];
+}
+
 class Script2Platform {
   constructor(log, config, api) {
     this.log = log;
@@ -65,7 +78,7 @@ class Script2Platform {
   }
 
   discoverDevices() {
-    const devices = Array.isArray(this.config.devices) ? this.config.devices : [];
+    const devices = getConfiguredDevices(this.config);
 
     if (devices.length === 0) {
       this.log.warn("No devices configured for Script2Platform.");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.4.3-beta.3",
+  "version": "0.4.3-beta.7",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Add explicit support for stateless (single-action trigger) devices in the platform `devices` list so Config UI and runtime can manage mixed device types. 
- Ensure Config UI form conditions evaluate correctly for array entries and enforce required fields for stateful vs stateless devices. 
- Prevent invalid or irrelevant properties from being applied to accessories at runtime by sanitizing device config objects.

### Description
- Added `sanitizeDeviceConfig` and applied it in `discoverDevices` so each device is normalized based on `device_type` (removing irrelevant keys for `stateless` or `switch`) in `index.js`. 
- Extended README with Config UI behavior notes and examples for legacy `devices`, stateless examples, and mixed `devices` lists. 
- Updated `config.schema.json` to require `device_type`, convert `oneOf` enum entries to `const`, update `form` conditional `functionBody` to reference `arrayIndices` for per-item visibility, and enforce `state` or `fileState` for stateful devices while requiring `trigger` for stateless ones. 
- Bumped package version in `package.json` to `0.4.3-beta.7`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077e4377c0832ca977b97d46703570)