### PR TITLE
Add grouped Config UI sections, legacy `devices` compatibility, and platform discovery sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,74 @@ Name            | Value         | Required                                    | 
 Type note: use JSON booleans for `polling` (for example `"polling": true`), not strings like `"polling": "true"`.
 
 
+### Config UI behavior with existing `devices` arrays
+
+If you already have a platform config with `devices` (for example 8 existing ON/OFF switches), Config UI X will load those entries into the same **Devices** array editor.
+
+- Your existing entries remain editable and are **not** removed.
+- Each existing device appears as one item in the Devices list (using the plugin schema form for that row).
+- Saving from Config UI X preserves backward compatibility with existing `devices`-based platform configs.
+
+Example (8 existing stateful switches in legacy `devices` list shape):
+
+```json
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "devices": [
+      { "name": "Outlet 1", "on": "/opt/scripts/on.sh 1", "off": "/opt/scripts/off.sh 1", "state": "/opt/scripts/state.sh 1" },
+      { "name": "Outlet 2", "on": "/opt/scripts/on.sh 2", "off": "/opt/scripts/off.sh 2", "state": "/opt/scripts/state.sh 2" },
+      { "name": "Outlet 3", "on": "/opt/scripts/on.sh 3", "off": "/opt/scripts/off.sh 3", "state": "/opt/scripts/state.sh 3" },
+      { "name": "Outlet 4", "on": "/opt/scripts/on.sh 4", "off": "/opt/scripts/off.sh 4", "state": "/opt/scripts/state.sh 4" },
+      { "name": "Outlet 5", "on": "/opt/scripts/on.sh 5", "off": "/opt/scripts/off.sh 5", "state": "/opt/scripts/state.sh 5" },
+      { "name": "Outlet 6", "on": "/opt/scripts/on.sh 6", "off": "/opt/scripts/off.sh 6", "state": "/opt/scripts/state.sh 6" },
+      { "name": "Outlet 7", "on": "/opt/scripts/on.sh 7", "off": "/opt/scripts/off.sh 7", "state": "/opt/scripts/state.sh 7" },
+      { "name": "Outlet 8", "on": "/opt/scripts/on.sh 8", "off": "/opt/scripts/off.sh 8", "state": "/opt/scripts/state.sh 8" }
+    ]
+  }
+]
+```
+
+
+
+### New grouped Config UI sections (recommended)
+
+You can now configure devices in two dedicated platform arrays:
+
+- `On/Off Switches`: normal ON/OFF switches
+- `Stateless Switches`: single-action trigger switches
+
+These are recommended for Config UI X because they avoid complex per-row field toggling.
+Legacy `devices` is still supported for backward compatibility.
+
+Example:
+
+```json
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "On/Off Switches": [
+      {
+        "name": "Outlet 1",
+        "on": "/var/homebridge/rpc3control/on.sh 1",
+        "off": "/var/homebridge/rpc3control/off.sh 1",
+        "state": "/var/homebridge/rpc3control/state.sh 1"
+      }
+    ],
+    "Stateless Switches": [
+      {
+        "name": "Outlet 1 Reboot",
+        "trigger": "/var/homebridge/rpc3control/reboot.sh 1",
+        "auto_reset_ms": 500,
+        "stateless_trigger_on": "off"
+      }
+    ]
+  }
+]
+```
+
 ### State script behavior
 - The `state` script output is normalized to lowercase and compared against `on_value` (default `true`).
 - If both `fileState` and `state` are configured, `fileState` takes precedence: the state script is not used for status changes and the configured file flag is used instead.
@@ -117,7 +185,7 @@ Type note: use JSON booleans for `polling` (for example `"polling": true`), not 
 - `stateless_trigger_on: "off"`: press OFF to trigger, then auto-reset to ON (default tile state is ON).
 - Stateful options (`state`, `fileState`, `polling`, `on_value`) are ignored for stateless devices.
 
-Example:
+Example (single stateless device object):
 
 ```json
 {
@@ -128,6 +196,34 @@ Example:
   "stateless_trigger_on": "off",
   "unique_serial": "rpc3-outlet1-reboot"
 }
+```
+
+Example (mixed platform with stateful + stateless in one `devices` list):
+
+```json
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "devices": [
+      {
+        "name": "Rack PDU Outlet 1",
+        "device_type": "switch",
+        "on": "/var/homebridge/rpc3control/on.sh 1",
+        "off": "/var/homebridge/rpc3control/off.sh 1",
+        "state": "/var/homebridge/rpc3control/state.sh 1",
+        "on_value": "true"
+      },
+      {
+        "name": "Rack PDU Outlet 1 Reboot",
+        "device_type": "stateless",
+        "trigger": "/var/homebridge/rpc3control/reboot.sh 1",
+        "auto_reset_ms": 500,
+        "stateless_trigger_on": "off"
+      }
+    ]
+  }
+]
 ```
 
 ## Installation
@@ -357,3 +453,23 @@ sudo -u homebridge /home/homebridge/scripts/light_off.sh
 - Add logging and fail-fast flags (`set -euo pipefail`) in shell scripts.
 - Keep scripts minimal; move complex logic to separate files you can test independently.
 - Restart Homebridge after major script/permission changes to ensure a clean environment.
+
+
+### Migration notes (legacy `devices` -> grouped sections)
+
+- **No breaking change**: legacy `devices` remains supported as-is. You do not need to change config for existing installs.
+- HomeKit accessory UUIDs are generated from the accessory **name** (`homebridge-script2:<name>`).
+- If you copy a legacy device into `On/Off Switches` with the **same name** and remove it from `devices`, Homebridge should match it to the same cached accessory (not create a new one).
+- If you keep duplicate entries with the same name in both sections at once, behavior is undefined and may cause duplicate-config conflicts.
+
+Recommended migration steps:
+1. Stop Homebridge.
+2. Move one legacy `devices` entry at a time into `On/Off Switches` (or `Stateless Switches`) **with the exact same `name`**.
+3. Remove the moved entry from legacy `devices`.
+4. Start Homebridge and verify the accessory still appears as the same device in HomeKit.
+5. Repeat for remaining devices.
+
+Do users need to remove old devices from HomeKit?
+- **Usually no**, if the name is unchanged during migration.
+- **Yes**, only if you intentionally rename accessories (name change = new UUID/new HomeKit accessory identity).
+

--- a/config.schema.json
+++ b/config.schema.json
@@ -21,9 +21,9 @@
         "description": "Display name for this platform instance in Homebridge."
       },
       "devices": {
-        "title": "Devices",
+        "title": "Legacy Devices (Read-only compatibility section)",
         "type": "array",
-        "description": "Define one or more Script2 accessories managed by this platform.",
+        "description": "Deprecated legacy mixed list. Existing setups continue to work at runtime. Move entries into Stateful/Stateless sections for best UI experience.",
         "items": {
           "title": "Device",
           "type": "object",
@@ -40,18 +40,15 @@
               "oneOf": [
                 {
                   "title": "Switch (ON/OFF)",
-                  "enum": [
-                    "switch"
-                  ]
+                  "const": "switch"
                 },
                 {
                   "title": "Stateless Trigger (single action)",
-                  "enum": [
-                    "stateless"
-                  ]
+                  "const": "stateless"
                 }
               ],
-              "description": "Use 'switch' for normal ON/OFF control, or 'stateless' for a single-action trigger that auto-resets OFF."
+              "description": "Use 'switch' for normal ON/OFF control, or 'stateless' for a single-action trigger that auto-resets OFF.",
+              "required": true
             },
             "on": {
               "title": "ON Command",
@@ -162,85 +159,85 @@
             {
               "key": "on",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "off",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "fileState",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "state",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "on_value",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_interval",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "polling_on_start",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "state_cache_ttl_ms",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "reset_state_cache_on_set",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "fail_on_state_exit_code",
               "condition": {
-                "functionBody": "return model.device_type !== 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type !== 'stateless'"
               }
             },
             {
               "key": "trigger",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type === 'stateless'"
               }
             },
             {
               "key": "auto_reset_ms",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type === 'stateless'"
               }
             },
             {
               "key": "stateless_trigger_on",
               "condition": {
-                "functionBody": "return model.device_type === 'stateless'"
+                "functionBody": "const i=(typeof arrayIndices==='number')?arrayIndices:((arrayIndices&&typeof arrayIndices.devices==='number')?arrayIndices.devices:-1); const d=(model&&Array.isArray(model.devices)&&i>=0)?(model.devices[i]||{}):(model||{}); return d.device_type === 'stateless'"
               }
             },
             "unique_serial"
@@ -265,11 +262,211 @@
                   "name",
                   "on",
                   "off"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "state"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fileState"
+                    ]
+                  }
                 ]
               }
             }
+          ],
+          "required": [
+            "name",
+            "device_type"
           ]
-        }
+        },
+        "expandable": true,
+        "expanded": false
+      },
+      "On/Off Switches": {
+        "title": "On/Off Switches",
+        "type": "array",
+        "description": "Recommended: configure standard ON/OFF switches here.",
+        "items": {
+          "title": "{{ value.name || \"New Stateful Switch\" }}",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Accessory Name",
+              "type": "string",
+              "required": true
+            },
+            "unique_serial": {
+              "title": "Unique Serial",
+              "type": "string",
+              "default": "script2 Serial Number",
+              "description": "Recommended unique serial per device for HomeKit apps."
+            },
+            "on": {
+              "title": "ON Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/on.sh 1"
+            },
+            "off": {
+              "title": "OFF Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/off.sh 1"
+            },
+            "fileState": {
+              "title": "State File Path",
+              "type": "string",
+              "description": "If set, the on/off state is based on file existence and overrides state command.",
+              "placeholder": "/var/homebridge/scripts/device1.flag"
+            },
+            "state": {
+              "title": "State Command",
+              "type": "string",
+              "description": "Command that prints current state (for example: true/false)."
+            },
+            "on_value": {
+              "title": "ON Match Value",
+              "type": "string",
+              "default": "true",
+              "description": "State command output value interpreted as ON."
+            },
+            "polling": {
+              "title": "Enable Polling",
+              "type": "boolean",
+              "default": false,
+              "description": "Poll state command periodically (ignored when State File Path is set)."
+            },
+            "polling_interval": {
+              "title": "Polling Interval (ms)",
+              "type": "integer",
+              "default": 5000,
+              "minimum": 250
+            },
+            "polling_on_start": {
+              "title": "Poll Immediately on Startup",
+              "type": "boolean",
+              "default": true
+            },
+            "state_cache_ttl_ms": {
+              "title": "State Cache TTL (ms)",
+              "type": "integer",
+              "default": 1000,
+              "minimum": 0,
+              "description": "Short cache for burst reads to avoid duplicate command execution."
+            },
+            "reset_state_cache_on_set": {
+              "title": "Reset State Cache on Manual Set",
+              "type": "boolean",
+              "default": false
+            },
+            "fail_on_state_exit_code": {
+              "title": "Fail on Non-zero State Exit Code",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "name",
+            "on",
+            "off"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "state"
+              ]
+            },
+            {
+              "required": [
+                "fileState"
+              ]
+            }
+          ],
+          "expandable": true,
+          "expanded": false,
+          "form": [
+            "name",
+            "on",
+            "off",
+            "fileState",
+            "state",
+            "on_value",
+            "polling",
+            "polling_interval",
+            "polling_on_start",
+            "state_cache_ttl_ms",
+            "reset_state_cache_on_set",
+            "fail_on_state_exit_code",
+            "unique_serial"
+          ]
+        },
+        "expandable": true,
+        "expanded": false
+      },
+      "Stateless Switches": {
+        "title": "Stateless Switches",
+        "type": "array",
+        "description": "Recommended: configure one-shot trigger devices here.",
+        "items": {
+          "title": "{{ value.name || \"New Stateless Trigger\" }}",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Accessory Name",
+              "type": "string",
+              "required": true
+            },
+            "unique_serial": {
+              "title": "Unique Serial",
+              "type": "string",
+              "default": "script2 Serial Number",
+              "description": "Recommended unique serial per device for HomeKit apps."
+            },
+            "trigger": {
+              "title": "Trigger Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/reboot.sh 1"
+            },
+            "auto_reset_ms": {
+              "title": "Auto Reset Delay (ms)",
+              "type": "integer",
+              "default": 500,
+              "minimum": 0
+            },
+            "stateless_trigger_on": {
+              "title": "Stateless Trigger On",
+              "type": "string",
+              "default": "on",
+              "oneOf": [
+                {
+                  "title": "Trigger on ON (default)",
+                  "const": "on"
+                },
+                {
+                  "title": "Trigger on OFF (default tile ON)",
+                  "const": "off"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "trigger"
+          ],
+          "expandable": true,
+          "expanded": false,
+          "form": [
+            "name",
+            "trigger",
+            "auto_reset_ms",
+            "stateless_trigger_on",
+            "unique_serial"
+          ]
+        },
+        "expandable": true,
+        "expanded": false
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,49 @@ module.exports = function (homebridge) {
   homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, Script2Platform, true);
 };
 
+
+function sanitizeDeviceConfig(deviceConfig) {
+  const sanitized = { ...(deviceConfig || {}) };
+  const deviceType = sanitized["device_type"] === "stateless" ? "stateless" : "switch";
+
+  if (deviceType === "stateless") {
+    delete sanitized["on"];
+    delete sanitized["off"];
+    delete sanitized["fileState"];
+    delete sanitized["state"];
+    delete sanitized["on_value"];
+    delete sanitized["polling"];
+    delete sanitized["polling_interval"];
+    delete sanitized["polling_on_start"];
+    delete sanitized["state_cache_ttl_ms"];
+    delete sanitized["reset_state_cache_on_set"];
+    delete sanitized["fail_on_state_exit_code"];
+  } else {
+    delete sanitized["trigger"];
+    delete sanitized["auto_reset_ms"];
+    delete sanitized["stateless_trigger_on"];
+  }
+
+  return sanitized;
+}
+
+
+function getConfiguredDevices(config) {
+  const legacyDevices = Array.isArray(config?.devices) ? config.devices : [];
+  const statefulDevices = Array.isArray(config?.["On/Off Switches"])
+    ? config["On/Off Switches"].map((device) => ({ ...device, device_type: "switch" }))
+    : Array.isArray(config?.stateful_devices)
+      ? config.stateful_devices.map((device) => ({ ...device, device_type: "switch" }))
+      : [];
+  const statelessDevices = Array.isArray(config?.["Stateless Switches"])
+    ? config["Stateless Switches"].map((device) => ({ ...device, device_type: "stateless" }))
+    : Array.isArray(config?.stateless_devices)
+      ? config.stateless_devices.map((device) => ({ ...device, device_type: "stateless" }))
+      : [];
+
+  return [...legacyDevices, ...statefulDevices, ...statelessDevices];
+}
+
 class Script2Platform {
   constructor(log, config, api) {
     this.log = log;
@@ -39,7 +82,7 @@ class Script2Platform {
   }
 
   discoverDevices() {
-    const devices = Array.isArray(this.config.devices) ? this.config.devices : [];
+    const devices = getConfiguredDevices(this.config);
 
     if (devices.length === 0) {
       this.log.warn("No devices configured for Script2Platform.");
@@ -48,7 +91,8 @@ class Script2Platform {
 
     const configuredUuids = new Set();
 
-    for (const deviceConfig of devices) {
+    for (const rawDeviceConfig of devices) {
+      const deviceConfig = sanitizeDeviceConfig(rawDeviceConfig);
       const name = deviceConfig?.name;
       if (!name) {
         this.log.error("Skipping platform device with missing required 'name'.");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.4.3-beta.3",
+  "version": "0.4.3-beta.8",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [


### PR DESCRIPTION
### Motivation

- Provide a better Homebridge Config UI experience by introducing dedicated grouped sections for stateful and stateless devices while preserving existing legacy `devices` configs for backward compatibility.
- Ensure the platform discovery code safely handles mixed-config shapes and normalizes device objects before accessory creation.
- Improve documentation and migration guidance in `README.md` to reduce user confusion when moving from legacy to grouped UI sections.

### Description

- Updated `config.schema.json` to add new UI arrays `On/Off Switches` and `Stateless Switches`, made the legacy `devices` array a compat section, and adjusted per-item form conditions, required rules, and presentation (expandable/expanded defaults). 
- Added `sanitizeDeviceConfig` and `getConfiguredDevices` helpers in `index.js` and changed `discoverDevices` to aggregate legacy, stateful, and stateless entries and sanitize each device before registering or restoring accessories. 
- Enhanced `README.md` with new Config UI behavior notes, examples for grouped and legacy configurations, stateless examples, and migration steps and warnings. 
- Bumped package version in `package.json` to `0.4.3-beta.8` and left `chokidar` dependency intact.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077e4377c0832ca977b97d46703570)