### PR TITLE
Add Homebridge Config UI X custom UI and split config into On/Off and Stateless sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Original plugin [homebridge-script](https://github.com/xxcombat/homebridge-scrip
 This plugin now includes a **Homebridge Config UI X** schema (`config.schema.json`) so you can add and manage `Script2Platform` devices directly from the UI instead of editing raw JSON manually. See below about upgrading to platform mode. Only use the user friendly Plugin Config UI X option if using the dynamic platform mode.
 
 - In Homebridge UI, go to **Plugins → homebridge-script2 → Plugin Config**.
-- Use the **Devices** list to add each Script2 switch/accessory and fill in commands/paths.
+- Use the **On/Off Switches** and **Stateless Switches** sections to add devices and fill in commands/paths.
 - Save and restart Homebridge when prompted.
 
 ## Platform mode
@@ -30,28 +30,41 @@ Homebridge Config UI schema is **platform-only** (dynamic platform) for reliable
 Because this plugin depends on external scripts and shell execution, it is highly recommended to run it in a dedicated **Child Bridge** for reliability and isolation.
 
 ### Platform configuration parameters
-Each entry in `devices` supports the same options as accessory mode:
+Recommended configuration is split into two arrays:
 
-Name            | Value         | Required                                    | Notes
---------------- | ------------- | ------------------------------------------- | -------------
-`name`          | _(custom)_    | yes                                         | Name of accessory that will appear in Home app and is required
-`on`            | _(custom)_    | yes                                         | Script/command to execute the on action
-`off`           | _(custom)_    | yes                                         | Script/command to execute the off action
+| Name | Value | Required | Notes |
+| --- | --- | --- | --- |
+| `on_off_switches` | array | no | Main section for standard ON/OFF switches |
+| `stateless_switches` | array | no | Main section for one-shot trigger switches |
+| `devices` | array | no (legacy only) | Legacy compatibility list (ON/OFF entries) |
 
-`device_type`  | `switch/stateless` | no (default `switch`)            | `switch` = normal ON/OFF behavior, `stateless` = single-action trigger
-`trigger`      | _(custom)_         | required for `stateless` devices | Script/command to execute when stateless trigger is pressed
-`auto_reset_ms`| integer ms         | no (default `500`)               | Delay before stateless trigger resets to its default state in Home app
-`stateless_trigger_on` | `on/off` | no (default `on`) | Stateless trigger edge: `on` triggers when toggled ON; `off` triggers when toggled OFF and defaults tile to ON
-`fileState`     | _(custom)_    | fileState or state is required (see note)   | File used as current state flag
-`state`         | _(custom)_    | fileState or state is required (see note)   | Script to determine current state
-`on_value`      | _(custom)_    | no* (default set to `"true"`)             | Value matched against `state` command output
-`polling`       | `true/false`  | no (default `false`)                       | Enables periodic polling for `state` command mode only
-`polling_interval` | integer ms | no (default `5000`)                        | Poll interval in milliseconds when `polling` is enabled
-`polling_on_start` | `true/false` | no (default `true`)                     | Immediately run a state poll when Homebridge starts
-`state_cache_ttl_ms` | integer ms | no (default `1000`)                     | Cache TTL for `state` reads to avoid duplicate script executions on burst GET requests
-`reset_state_cache_on_set` | `true/false` | no (default `false`)               | When enabled, successful manual ON/OFF actions reset the state cache timer and seed it with the set state
-`fail_on_state_exit_code` | `true/false` | no (default `false`)               | When enabled, non-zero exit code from the `state` command is treated as an error for that read request
-`unique_serial` | _(custom)_    | no (default set to `"Script2 Serial number"`) | Unique serial per device is recommended
+#### `on_off_switches` item parameters
+
+Name | Value | Required | Notes
+--- | --- | --- | ---
+`name` | _(custom)_ | yes | Accessory name shown in Home app
+`on` | _(custom)_ | yes | Script/command to execute the ON action
+`off` | _(custom)_ | yes | Script/command to execute the OFF action
+`fileState` | _(custom)_ | fileState or state | File flag used as current state; if set, it overrides `state`
+`state` | _(custom)_ | fileState or state | Script to determine current ON/OFF state
+`on_value` | _(custom)_ | no (default `"true"`) | Value matched against normalized `state` output
+`polling` | `true/false` | no (default `false`) | Enables periodic polling for `state` mode
+`polling_interval` | integer ms | no (default `5000`) | Poll interval when `polling` is enabled
+`polling_on_start` | `true/false` | no (default `true`) | Immediately runs state poll on startup
+`state_cache_ttl_ms` | integer ms | no (default `1000`) | Cache TTL for burst reads
+`reset_state_cache_on_set` | `true/false` | no (default `false`) | Resets/seeds state cache after successful manual set
+`fail_on_state_exit_code` | `true/false` | no (default `false`) | Treat non-zero `state` exit code as read error
+`unique_serial` | _(custom)_ | no | Unique serial per accessory is recommended
+
+#### `stateless_switches` item parameters
+
+Name | Value | Required | Notes
+--- | --- | --- | ---
+`name` | _(custom)_ | yes | Accessory name shown in Home app
+`trigger` | _(custom)_ | yes | Script/command to execute trigger action
+`auto_reset_ms` | integer ms | no | Delay before Home tile auto-resets
+`stateless_trigger_on` | `on/off` | no (default `on`) | `on` triggers on ON; `off` triggers on OFF (tile defaults to ON)
+`unique_serial` | _(custom)_ | no | Unique serial per accessory is recommended
 
 ### Platform configuration example
 
@@ -60,7 +73,7 @@ Name            | Value         | Required                                    | 
   {
     "platform": "Script2Platform",
     "name": "Script2",
-    "devices": [
+    "on_off_switches": [
       {
         "name": "RPC3 Socket 1",
         "on": "/var/homebridge/rpc3control/on.sh 1",
@@ -76,7 +89,8 @@ Name            | Value         | Required                                    | 
         "fail_on_state_exit_code": false,
         "unique_serial": "platform-1234567"
       }
-    ]
+    ],
+    "stateless_switches": []
   }
 ]
 ```
@@ -179,51 +193,21 @@ Example:
 
 
 ### Stateless trigger mode
-- Set `device_type` to `stateless` to create a single-action trigger accessory suitable for actions like outlet reboot.
-- In stateless mode, `trigger` runs on the configured edge via `stateless_trigger_on` (`on` by default).
-- `stateless_trigger_on: "on"`: press ON to trigger, then auto-reset to OFF.
-- `stateless_trigger_on: "off"`: press OFF to trigger, then auto-reset to ON (default tile state is ON).
-- Stateful options (`state`, `fileState`, `polling`, `on_value`) are ignored for stateless devices.
+- Configure trigger accessories in `stateless_switches`.
+- `stateless_trigger_on: "on"` (default): press ON to run trigger, then auto-reset to OFF.
+- `stateless_trigger_on: "off"`: press OFF to run trigger, then auto-reset to ON (default tile state ON).
+- No `none` mode is provided.
 
 Example (single stateless device object):
 
 ```json
 {
   "name": "RPC3 Outlet 1 Reboot",
-  "device_type": "stateless",
   "trigger": "/var/homebridge/rpc3control/reboot.sh 1",
   "auto_reset_ms": 500,
   "stateless_trigger_on": "off",
   "unique_serial": "rpc3-outlet1-reboot"
 }
-```
-
-Example (mixed platform with stateful + stateless in one `devices` list):
-
-```json
-"platforms": [
-  {
-    "platform": "Script2Platform",
-    "name": "Script2",
-    "devices": [
-      {
-        "name": "Rack PDU Outlet 1",
-        "device_type": "switch",
-        "on": "/var/homebridge/rpc3control/on.sh 1",
-        "off": "/var/homebridge/rpc3control/off.sh 1",
-        "state": "/var/homebridge/rpc3control/state.sh 1",
-        "on_value": "true"
-      },
-      {
-        "name": "Rack PDU Outlet 1 Reboot",
-        "device_type": "stateless",
-        "trigger": "/var/homebridge/rpc3control/reboot.sh 1",
-        "auto_reset_ms": 500,
-        "stateless_trigger_on": "off"
-      }
-    ]
-  }
-]
 ```
 
 ## Installation
@@ -234,6 +218,27 @@ Example (mixed platform with stateful + stateless in one `devices` list):
 3. Update your configuration file. See examples below that show the plugin working by using filestate for current state check as well as an example using state.sh script for current state check.
 4. Make sure scripts have been made executable (chmod +x scriptname.sh) and also accessible by the homebridge user. 
 
+
+### Legacy dynamic platform example (`platforms` with legacy `devices` list)
+
+```json
+"platforms": [
+  {
+    "platform": "Script2Platform",
+    "name": "Script2",
+    "devices": [
+      {
+        "name": "RPC3 Socket 1",
+        "on": "/var/homebridge/rpc3control/on.sh 1",
+        "off": "/var/homebridge/rpc3control/off.sh 1",
+        "state": "/var/homebridge/rpc3control/state.sh 1",
+        "on_value": "true",
+        "unique_serial": "legacy-platform-1234567"
+      }
+    ]
+  }
+]
+```
 
 ## Legacy accessory mode (still supported)
 
@@ -472,4 +477,3 @@ Recommended migration steps:
 Do users need to remove old devices from HomeKit?
 - **Usually no**, if the name is unchanged during migration.
 - **Yes**, only if you intentionally rename accessories (name change = new UUID/new HomeKit accessory identity).
-

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,6 +1,8 @@
 {
   "pluginAlias": "Script2Platform",
   "pluginType": "platform",
+  "customUi": true,
+  "customUiPath": "/homebridge-ui",
   "singular": true,
   "headerDisplay": "## homebridge-script2\nConfigure Script2 in Homebridge UI without editing JSON manually.",
   "schema": {
@@ -20,137 +22,18 @@
         "required": true,
         "description": "Display name for this platform instance in Homebridge."
       },
-      "devices": {
-        "title": "Legacy Devices (auto-migrate to On/Off on save)",
-        "type": "array",
-        "description": "Legacy compatibility list. Entries are treated as On/Off switches.",
-        "items": {
-          "title": "{{ value.name || \"New Stateful Switch\" }}",
-          "type": "object",
-          "properties": {
-            "name": {
-              "title": "Accessory Name",
-              "type": "string",
-              "required": true
-            },
-            "unique_serial": {
-              "title": "Unique Serial",
-              "type": "string",
-              "description": "Recommended unique serial per device for HomeKit apps."
-            },
-            "on": {
-              "title": "ON Command",
-              "type": "string",
-              "placeholder": "/var/homebridge/scripts/on.sh 1"
-            },
-            "off": {
-              "title": "OFF Command",
-              "type": "string",
-              "placeholder": "/var/homebridge/scripts/off.sh 1"
-            },
-            "fileState": {
-              "title": "State File Path",
-              "type": "string",
-              "description": "If set, the on/off state is based on file existence and overrides state command.",
-              "placeholder": "/var/homebridge/scripts/device1.flag"
-            },
-            "state": {
-              "title": "State Command",
-              "type": "string",
-              "description": "Command that prints current state (for example: true/false)."
-            },
-            "on_value": {
-              "title": "ON Match Value",
-              "type": "string",
-              "default": "true",
-              "description": "State command output value interpreted as ON."
-            },
-            "polling": {
-              "title": "Enable Polling",
-              "type": "boolean",
-              "default": false,
-              "description": "Poll state command periodically (ignored when State File Path is set)."
-            },
-            "polling_interval": {
-              "title": "Polling Interval (ms)",
-              "type": "integer",
-              "default": 5000,
-              "minimum": 250
-            },
-            "polling_on_start": {
-              "title": "Poll Immediately on Startup",
-              "type": "boolean",
-              "default": true
-            },
-            "state_cache_ttl_ms": {
-              "title": "State Cache TTL (ms)",
-              "type": "integer",
-              "default": 1000,
-              "minimum": 0,
-              "description": "Short cache for burst reads to avoid duplicate command execution."
-            },
-            "reset_state_cache_on_set": {
-              "title": "Reset State Cache on Manual Set",
-              "type": "boolean",
-              "default": false
-            },
-            "fail_on_state_exit_code": {
-              "title": "Fail on Non-zero State Exit Code",
-              "type": "boolean",
-              "default": false
-            }
-          },
-          "required": [
-            "name",
-            "on",
-            "off"
-          ],
-          "anyOf": [
-            {
-              "required": [
-                "state"
-              ]
-            },
-            {
-              "required": [
-                "fileState"
-              ]
-            }
-          ],
-          "expandable": true,
-          "expanded": false,
-          "form": [
-            "name",
-            "on",
-            "off",
-            "fileState",
-            "state",
-            "on_value",
-            "polling",
-            "polling_interval",
-            "polling_on_start",
-            "state_cache_ttl_ms",
-            "reset_state_cache_on_set",
-            "fail_on_state_exit_code",
-            "unique_serial"
-          ]
-        },
-        "expandable": true,
-        "expanded": false,
-        "default": []
-      },
       "on_off_switches": {
         "title": "On/Off Switches",
         "type": "array",
-        "description": "Recommended: configure standard ON/OFF switches here.",
+        "minItems": 0,
+        "description": "Configure standard ON/OFF switches in this section.",
         "items": {
           "title": "{{ value.name || \"New Stateful Switch\" }}",
           "type": "object",
           "properties": {
             "name": {
               "title": "Accessory Name",
-              "type": "string",
-              "required": true
+              "type": "string"
             },
             "unique_serial": {
               "title": "Unique Serial",
@@ -219,6 +102,7 @@
               "default": false
             }
           },
+          "description": "Use Add Device to create entries.",
           "required": [
             "name",
             "on",
@@ -261,15 +145,15 @@
       "stateless_switches": {
         "title": "Stateless Switches",
         "type": "array",
-        "description": "Recommended: configure one-shot trigger devices here.",
+        "minItems": 0,
+        "description": "Configure stateless switch device in this section.",
         "items": {
           "title": "{{ value.name || \"New Stateless Trigger\" }}",
           "type": "object",
           "properties": {
             "name": {
               "title": "Accessory Name",
-              "type": "string",
-              "required": true
+              "type": "string"
             },
             "unique_serial": {
               "title": "Unique Serial",
@@ -289,18 +173,21 @@
             "stateless_trigger_on": {
               "title": "Stateless Trigger On",
               "type": "string",
+              "default": "on",
+              "description": "Trigger on On: runs the command when the switch is turned ON. Trigger on Off: runs the command when turned OFF (tile defaults to ON).",
               "oneOf": [
                 {
-                  "title": "Trigger on ON (default)",
+                  "title": "Trigger on On",
                   "const": "on"
                 },
                 {
-                  "title": "Trigger on OFF (default tile ON)",
+                  "title": "Trigger on Off",
                   "const": "off"
                 }
               ]
             }
           },
+          "description": "Use Add Device to create entries.",
           "required": [
             "name",
             "trigger"
@@ -318,6 +205,128 @@
         "expandable": true,
         "expanded": false,
         "default": []
+      },
+      "devices": {
+        "title": "Legacy Devices Config",
+        "type": "array",
+        "minItems": 0,
+        "description": "Legacy compatibility list. Entries are treated as On/Off switches.",
+        "condition": {
+          "functionBody": "return Array.isArray(model.devices) && model.devices.length > 0;"
+        },
+        "items": {
+          "title": "{{ value.name || \"New Stateful Switch\" }}",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Accessory Name",
+              "type": "string"
+            },
+            "unique_serial": {
+              "title": "Unique Serial",
+              "type": "string",
+              "description": "Recommended unique serial per device for HomeKit apps."
+            },
+            "on": {
+              "title": "ON Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/on.sh 1"
+            },
+            "off": {
+              "title": "OFF Command",
+              "type": "string",
+              "placeholder": "/var/homebridge/scripts/off.sh 1"
+            },
+            "fileState": {
+              "title": "State File Path",
+              "type": "string",
+              "description": "If set, the on/off state is based on file existence and overrides state command.",
+              "placeholder": "/var/homebridge/scripts/device1.flag"
+            },
+            "state": {
+              "title": "State Command",
+              "type": "string",
+              "description": "Command that prints current state (for example: true/false)."
+            },
+            "on_value": {
+              "title": "ON Match Value",
+              "type": "string",
+              "default": "true",
+              "description": "State command output value interpreted as ON."
+            },
+            "polling": {
+              "title": "Enable Polling",
+              "type": "boolean",
+              "default": false,
+              "description": "Poll state command periodically (ignored when State File Path is set)."
+            },
+            "polling_interval": {
+              "title": "Polling Interval (ms)",
+              "type": "integer",
+              "default": 5000,
+              "minimum": 250
+            },
+            "polling_on_start": {
+              "title": "Poll Immediately on Startup",
+              "type": "boolean",
+              "default": true
+            },
+            "state_cache_ttl_ms": {
+              "title": "State Cache TTL (ms)",
+              "type": "integer",
+              "default": 1000,
+              "minimum": 0,
+              "description": "Short cache for burst reads to avoid duplicate command execution."
+            },
+            "reset_state_cache_on_set": {
+              "title": "Reset State Cache on Manual Set",
+              "type": "boolean",
+              "default": false
+            },
+            "fail_on_state_exit_code": {
+              "title": "Fail on Non-zero State Exit Code",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "description": "Use Add Device to create entries.",
+          "required": [
+            "name",
+            "on",
+            "off"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "state"
+              ]
+            },
+            {
+              "required": [
+                "fileState"
+              ]
+            }
+          ],
+          "expandable": true,
+          "expanded": false,
+          "form": [
+            "name",
+            "on",
+            "off",
+            "fileState",
+            "state",
+            "on_value",
+            "polling",
+            "polling_interval",
+            "polling_on_start",
+            "state_cache_ttl_ms",
+            "reset_state_cache_on_set",
+            "fail_on_state_exit_code",
+            "unique_serial"
+          ]
+        },
+        "expandable": true,
+        "expanded": false
       }
     }
   }

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Script2 Config</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 16px; }
+    h3 { margin-top: 24px; }
+    .row { border: 1px solid #ddd; padding: 10px; margin: 8px 0; }
+    label { display:block; margin: 6px 0 2px; font-size: 12px; color:#444; }
+    input, select { width: 100%; padding: 6px; }
+    .actions { margin-top: 16px; }
+    button { padding: 8px 12px; margin-right: 8px; }
+  </style>
+</head>
+<body>
+  <h2>homebridge-script2 custom config UI</h2>
+  <div id="app"></div>
+  <div class="actions">
+    <button id="saveBtn">Save</button>
+  </div>
+  <script src="index.js"></script>
+</body>
+</html>

--- a/homebridge-ui/public/index.js
+++ b/homebridge-ui/public/index.js
@@ -1,0 +1,97 @@
+/* global homebridge */
+
+let pluginConfig = {};
+
+const state = {
+  on_off_switches: [],
+  stateless_switches: [],
+  devices: [],
+};
+
+function el(tag, props = {}, children = []) {
+  const node = document.createElement(tag);
+  Object.entries(props).forEach(([k, v]) => {
+    if (k === 'text') node.textContent = v;
+    else if (k.startsWith('on') && typeof v === 'function') node.addEventListener(k.slice(2).toLowerCase(), v);
+    else node.setAttribute(k, v);
+  });
+  children.forEach(c => node.appendChild(c));
+  return node;
+}
+
+function textInput(value, onChange) {
+  return el('input', { value: value || '', oninput: (e) => onChange(e.target.value) });
+}
+
+function renderDeviceRow(device, key, idx, fields) {
+  const row = el('div', { class: 'row' });
+  fields.forEach(([field, label]) => {
+    row.appendChild(el('label', { text: label }));
+    row.appendChild(textInput(device[field], (v) => { state[key][idx][field] = v; }));
+  });
+  row.appendChild(el('button', { text: 'Remove', onclick: () => { state[key].splice(idx, 1); render(); } }));
+  return row;
+}
+
+function renderSection(title, key, fields) {
+  const section = el('div');
+  section.appendChild(el('h3', { text: title }));
+
+  (state[key] || []).forEach((d, i) => section.appendChild(renderDeviceRow(d, key, i, fields)));
+
+  section.appendChild(el('button', {
+    text: `Add ${title.slice(0, -1)}`,
+    onclick: () => { state[key].push({}); render(); },
+  }));
+
+  return section;
+}
+
+function render() {
+  const app = document.getElementById('app');
+  app.innerHTML = '';
+
+  app.appendChild(renderSection('On/Off Switches', 'on_off_switches', [
+    ['name', 'Accessory Name'], ['on', 'ON Command'], ['off', 'OFF Command'], ['state', 'State Command'], ['fileState', 'State File Path'],
+  ]));
+
+  app.appendChild(renderSection('Stateless Switches', 'stateless_switches', [
+    ['name', 'Accessory Name'], ['trigger', 'Trigger Command'], ['auto_reset_ms', 'Auto Reset Delay (ms)'], ['stateless_trigger_on', 'Stateless Trigger On (on/off)'],
+  ]));
+
+  if ((state.devices || []).length > 0) {
+    app.appendChild(renderSection('Legacy Devices Config', 'devices', [
+      ['name', 'Accessory Name'], ['on', 'ON Command'], ['off', 'OFF Command'], ['state', 'State Command'], ['fileState', 'State File Path'],
+    ]));
+  }
+}
+
+async function load() {
+  const config = await homebridge.getPluginConfig();
+  pluginConfig = (config && config[0]) ? config[0] : {};
+
+  state.on_off_switches = Array.isArray(pluginConfig.on_off_switches) ? pluginConfig.on_off_switches : [];
+  state.stateless_switches = Array.isArray(pluginConfig.stateless_switches) ? pluginConfig.stateless_switches : [];
+  state.devices = Array.isArray(pluginConfig.devices) ? pluginConfig.devices : [];
+
+  render();
+}
+
+async function save() {
+  const next = {
+    ...pluginConfig,
+    platform: 'Script2Platform',
+    name: pluginConfig.name || 'Script2',
+    on_off_switches: state.on_off_switches,
+    stateless_switches: state.stateless_switches,
+  };
+
+  if (state.devices.length > 0) next.devices = state.devices;
+  else delete next.devices;
+
+  await homebridge.updatePluginConfig([next]);
+  await homebridge.savePluginConfig();
+}
+
+document.getElementById('saveBtn').addEventListener('click', save);
+load();

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { HomebridgePluginUiServer } = require('@homebridge/plugin-ui-utils');
+
+class Script2UiServer extends HomebridgePluginUiServer {
+  constructor() {
+    super();
+    this.ready();
+  }
+}
+
+(() => new Script2UiServer())();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-script2",
-  "version": "0.4.3-beta.10",
+  "version": "0.4.3-beta.15",
   "license": "MIT",
   "description": "script plugin for homebridge: https://github.com/nfarina/homebridge",
   "keywords": [
@@ -16,6 +16,7 @@
     "node": ">=20.19.0"
   },
   "dependencies": {
+    "@homebridge/plugin-ui-utils": "^2.0.1",
     "chokidar": "5.0.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a first-class Homebridge Config UI X experience for the plugin so users can manage devices via a friendly UI instead of editing raw JSON. 
- Introduce explicit `on_off_switches` and `stateless_switches` sections to clarify configuration and separate stateful vs. one-shot trigger devices. 
- Preserve backward compatibility with existing `devices`-based configs while encouraging migration to the new grouped sections. 

### Description
- Update `README.md` to document the new `on_off_switches` and `stateless_switches` sections, show examples, explain migration steps, and reorganize installation instructions. 
- Extend `config.schema.json` to declare UI metadata (`customUi`, `customUiPath`), add `on_off_switches` and `stateless_switches` arrays with validation/form layout, and keep a conditional `devices` legacy section for backward compatibility. 
- Add a minimal custom UI under `homebridge-ui/` including `public/index.html`, `public/index.js` (loads/saves plugin config and renders simple add/remove editors), and `server.js` which exposes a `HomebridgePluginUiServer` entrypoint. 
- Bump package `version` and add `@homebridge/plugin-ui-utils` to `dependencies` to support the UI server integration. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e90cd1d0832c979c4e3129bdaa6a)